### PR TITLE
fix(jarvis): honor explicit scheduler execution mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.5.4",
+    "version": "2.5.5",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [
@@ -125,7 +125,7 @@
       "name": "clio-jarvis",
       "source": "./clio-kit-mcp-servers/jarvis",
       "description": "JARVIS-CD MCP with a compact user pipeline contract and explicit admin compatibility profiles",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "category": "development",
       "keywords": [
         "pipeline-management",

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Agents should discover first, install only when needed, then pass the exact
 | **`geo`** | 2.2.3 | Geospatial | Render GeoJSON vector layers with basemaps | `clio-kit mcp-server geo` |
 | **`geojson`** | 2.2.3 | Geospatial | Inspect, validate, and summarize GeoJSON | `clio-kit mcp-server geojson` |
 | **`hdf5`** | 2.2.3 | Data I/O | HPC-optimized scientific data with 27 tools, AI insights, caching, streaming | `clio-kit mcp-server hdf5` |
-| **`jarvis`** | 3.2.2 | Workflow | Durable pipeline, bounded package discovery, progress, artifact, and service-runtime management | `clio-kit mcp-server jarvis` |
+| **`jarvis`** | 3.2.3 | Workflow | Durable pipeline, bounded package discovery, progress, artifact, and service-runtime management | `clio-kit mcp-server jarvis` |
 | **`lmod`** | 2.2.3 | Environment | Environment module management | `clio-kit mcp-server lmod` |
 | **`ndp`** | 2.2.3 | Data Protocol | Search and discover datasets across CKAN instances | `clio-kit mcp-server ndp` |
 | **`node-hardware`** | 2.2.3 | System | System hardware information | `clio-kit mcp-server node-hardware` |

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/.claude-plugin/plugin.json
+++ b/clio-kit-mcp-servers/jarvis/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "clio-jarvis",
   "description": "JARVIS-CD MCP with a compact user pipeline contract and explicit admin compatibility profiles",
-  "version": "3.2.2"
+  "version": "3.2.3"
 }

--- a/clio-kit-mcp-servers/jarvis/pyproject.toml
+++ b/clio-kit-mcp-servers/jarvis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jarvis-mcp"
-version = "3.2.2"
+version = "3.2.3"
 description = "JARVIS-CD MCP with a compact user pipeline contract and explicit admin compatibility profiles"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.iowarp/jarvis-mcp",
   "title": "CLIO Jarvis",
   "description": "JARVIS-CD MCP with a compact user pipeline contract and explicit admin compatibility profiles",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "repository": {
     "url": "https://github.com/iowarp/clio-kit",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/__init__.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/__init__.py
@@ -3,12 +3,12 @@ Jarvis MCP Server
 
 Jarvis-CD MCP - Pipeline Management for High-Performance Computing with comprehensive workflow operations
 
-Version: 3.2.2
+Version: 3.2.3
 Author: IoWarp Team - Gnosis Research Center
 License: BSD-3-Clause
 """
 
-__version__ = "3.2.2"
+__version__ = "3.2.3"
 __author__ = "IoWarp Team - Gnosis Research Center"
 __email__ = "grc@illinoistech.edu"
 __license__ = "BSD-3-Clause"

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
@@ -2414,7 +2414,7 @@ def _execution_intent_to_pipeline_config(
             if mode == "auto" and set(values) <= {"mode"}:
                 return {}
             raise ToolError("no supported cluster scheduler detected on this machine")
-        if set(values) <= {"mode"}:
+        if mode == "auto" and set(values) <= {"mode"}:
             return {}
         scheduler: dict[str, Any] = {"name": scheduler_name}
         mapping = {

--- a/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
@@ -513,17 +513,22 @@ class TestPipelineToolsDirect:
         ):
             create_handler.return_value = {"pipeline_id": "new", "status": "created"}
 
-            from jarvis_mcp.server import jarvis_create_pipeline_tool
+            from jarvis_mcp.server import (
+                ExecutionIntent,
+                jarvis_create_pipeline_tool,
+            )
 
             result = await jarvis_create_pipeline_tool(
                 "new",
-                execution={
-                    "mode": "cluster",
-                    "nodes": 4,
-                    "tasks_per_node": 20,
-                    "walltime": "00:30:00",
-                    "exclusive": True,
-                },
+                execution=ExecutionIntent.model_validate(
+                    {
+                        "mode": "cluster",
+                        "nodes": 4,
+                        "tasks_per_node": 20,
+                        "walltime": "00:30:00",
+                        "exclusive": True,
+                    }
+                ),
             )
 
             assert result["status"] == "created"
@@ -707,16 +712,18 @@ class TestPipelineToolsDirect:
         ):
             run_handler.return_value = {"pipeline_id": "test", "status": "submitted"}
 
-            from jarvis_mcp.server import jarvis_run_tool
+            from jarvis_mcp.server import ExecutionIntent, jarvis_run_tool
 
             result = await jarvis_run_tool(
                 "test",
-                execution={
-                    "mode": "cluster",
-                    "nodes": 2,
-                    "tasks": 40,
-                    "partition": "compute",
-                },
+                execution=ExecutionIntent.model_validate(
+                    {
+                        "mode": "cluster",
+                        "nodes": 2,
+                        "tasks": 40,
+                        "partition": "compute",
+                    }
+                ),
             )
 
             assert result["status"] == "submitted"
@@ -738,16 +745,70 @@ class TestPipelineToolsDirect:
             )
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("requested_mode", "native_mode", "pipeline_config"),
+        [
+            (
+                "scheduler",
+                "scheduler",
+                {"scheduler": {"name": "slurm"}},
+            ),
+            (
+                "cluster",
+                "scheduler",
+                {"scheduler": {"name": "slurm"}},
+            ),
+            ("auto", "auto", {}),
+            (
+                "direct",
+                "direct",
+                {"scheduler": None, "hostfile": None},
+            ),
+        ],
+    )
+    async def test_jarvis_run_tool_preserves_explicit_execution_mode(
+        self,
+        requested_mode: str,
+        native_mode: str,
+        pipeline_config: dict[str, object],
+    ) -> None:
+        """A mode-only intent reaches JARVIS with its complete backend selection."""
+        with (
+            patch("jarvis_mcp.server.run_pipeline") as run_handler,
+            patch.dict("os.environ", {"JARVIS_MCP_SCHEDULER": "slurm"}, clear=True),
+        ):
+            run_handler.return_value = {"pipeline_id": "test", "status": "submitted"}
+
+            from jarvis_mcp.server import ExecutionIntent, jarvis_run_tool
+
+            await jarvis_run_tool(
+                "test",
+                execution=ExecutionIntent.model_validate({"mode": requested_mode}),
+            )
+
+        run_handler.assert_called_once_with(
+            "test",
+            mode=native_mode,
+            submit=True,
+            wait=False,
+            execution_id=None,
+            spack_specs=None,
+            pipeline_config=pipeline_config,
+        )
+
+    @pytest.mark.asyncio
     async def test_jarvis_run_tool_maps_hostfile_hosts(self):
         """Hostfile intent can be supplied as semantic host names."""
         with patch("jarvis_mcp.server.run_pipeline") as run_handler:
             run_handler.return_value = {"pipeline_id": "test", "status": "running"}
 
-            from jarvis_mcp.server import jarvis_run_tool
+            from jarvis_mcp.server import ExecutionIntent, jarvis_run_tool
 
             await jarvis_run_tool(
                 "test",
-                execution={"mode": "hostfile", "hosts": ["node-a", "node-b"]},
+                execution=ExecutionIntent.model_validate(
+                    {"mode": "hostfile", "hosts": ["node-a", "node-b"]}
+                ),
             )
 
             run_handler.assert_called_once_with(
@@ -967,8 +1028,12 @@ class TestPipelineToolsDirect:
         with pytest.raises(ToolError):
             _execution_intent_to_pipeline_config(execution)
 
-    def test_execution_intent_cluster_requires_scheduler(self):
-        """Explicit cluster mode fails if no scheduler exists on the MCP host."""
+    @pytest.mark.parametrize("mode", ["cluster", "scheduler"])
+    def test_explicit_scheduler_intent_requires_detected_scheduler(
+        self,
+        mode: str,
+    ) -> None:
+        """Explicit scheduler modes fail if no scheduler exists on the MCP host."""
         with (
             patch.dict("os.environ", {}, clear=True),
             patch("shutil.which", return_value=None),
@@ -976,7 +1041,7 @@ class TestPipelineToolsDirect:
             from jarvis_mcp.server import _execution_intent_to_pipeline_config
 
             with pytest.raises(ToolError, match="no supported cluster scheduler"):
-                _execution_intent_to_pipeline_config({"mode": "cluster", "nodes": 2})
+                _execution_intent_to_pipeline_config({"mode": mode})
 
     def test_execution_intent_auto_without_scheduler_is_noop(self):
         """Auto mode does not overwrite an existing pipeline on non-scheduler hosts."""
@@ -1011,15 +1076,31 @@ class TestPipelineToolsDirect:
         ):
             assert _detect_scheduler_name() == "slurm"
 
-    def test_execution_intent_cluster_mode_without_options_preserves_pipeline(self):
-        """Cluster auto-detection without resource options leaves pipeline config intact."""
+    @pytest.mark.parametrize("mode", ["cluster", "scheduler"])
+    def test_explicit_scheduler_intent_without_options_selects_detected_scheduler(
+        self,
+        mode: str,
+    ) -> None:
+        """Explicit scheduler modes persist backend selection without resource overrides."""
         from jarvis_mcp.server import _execution_intent_to_pipeline_config
 
         with (
             patch.dict("os.environ", {}, clear=True),
             patch("shutil.which", return_value="/usr/bin/sbatch"),
         ):
-            assert _execution_intent_to_pipeline_config({"mode": "cluster"}) == {}
+            assert _execution_intent_to_pipeline_config({"mode": mode}) == {
+                "scheduler": {"name": "slurm"}
+            }
+
+    def test_execution_intent_auto_with_scheduler_preserves_pipeline(self):
+        """Auto mode without overrides leaves existing scheduler configuration intact."""
+        from jarvis_mcp.server import _execution_intent_to_pipeline_config
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("shutil.which", return_value="/usr/bin/sbatch"),
+        ):
+            assert _execution_intent_to_pipeline_config({"mode": "auto"}) == {}
 
     def test_execution_intent_hostfile_entries(self):
         """Hostfile mode can materialize explicit host entries."""

--- a/clio-kit-mcp-servers/jarvis/uv.lock
+++ b/clio-kit-mcp-servers/jarvis/uv.lock
@@ -813,7 +813,7 @@ requires-dist = [
 
 [[package]]
 name = "jarvis-mcp"
-version = "3.2.2"
+version = "3.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/mcp-server-versions.toml
+++ b/mcp-server-versions.toml
@@ -9,7 +9,7 @@ publish = ["jarvis"]
 # Generated website metadata must not depend on the wall clock. Advance this
 # date intentionally whenever current contract metadata is regenerated.
 [documentation]
-updated = "2026-07-15"
+updated = "2026-07-17"
 
 # MCP Registry server versions describe each agent-facing contract. They are
 # intentionally independent of the clio-kit PyPI distribution version, which
@@ -23,7 +23,7 @@ darshan = "2.2.3"
 geo = "2.2.3"
 geojson = "2.2.3"
 hdf5 = "2.2.3"
-jarvis = "3.2.2"
+jarvis = "3.2.3"
 lmod = "2.2.3"
 ndp = "2.2.3"
 node-hardware = "2.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.5.4"
+version = "2.5.5"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.5.4"
+version = "2.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Explicit `scheduler` and `cluster` execution intents now persist the detected scheduler even when no resource overrides are supplied. `auto` continues to preserve the pipeline's existing backend and `direct` continues to clear scheduler state.

This releases clio-kit 2.5.5 and only advances the changed JARVIS MCP contract to 3.2.3. All other MCP contract versions remain unchanged. Two manifest-generation passes were byte-deterministic; focused JARVIS tests passed (25 passed), with Ruff, Pyright, and diff checks clean.