### PR TITLE
feat(launcher): bound the private MCP runtime cache — evict-on-upgrade + gc (#334)

### DIFF
--- a/src/clio_kit/__init__.py
+++ b/src/clio_kit/__init__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import dataclasses
 import hashlib
 import importlib.metadata as importlib_metadata
 import json
@@ -11,6 +12,16 @@ import tempfile
 from pathlib import Path
 import click
 
+from clio_kit.env_cache import (
+    CacheInUseError,
+    EnvironmentInUseMarker,
+    collect_cache_gc,
+    default_event_emitter,
+    discover_servers,
+    load_cache_policy,
+    maintain_after_build,
+    measure_cache_budget,
+)
 from clio_kit.mcp_contracts import (
     load_mcp_user_contract,
     load_mcp_user_contract_index,
@@ -561,57 +572,138 @@ def mcp_server(server, branch, args):
 
     child_environment = subprocess_env_with_github_https_rewrite()
 
-    # Build the child launcher command.
     if branch:
-        # Run from git branch
+        # Run from a git branch: uvx owns its own ephemeral environment, so the
+        # bounded local runtime cache does not apply.
         cmd = [
             uvx_command(),
             "--from",
             f"git+https://github.com/iowarp/clio-kit.git@{branch}#subdirectory=clio-kit-mcp-servers/{actual_dir}",
             entry_command,
         ]
-    else:
-        # Run from local path in development mode
-        servers_path = get_servers_path()
-        server_path = servers_path / actual_dir
+        cmd.extend(args)
+        _run_child_command(cmd, entry_command, child_environment)
+        return
 
-        if server_path.exists():
-            # The root wheel includes each server's project and uv.lock. Use an
-            # immutable install in a source-and-lock-keyed cache so the exact
-            # outer wheel also binds the child dependency closure.
-            runtime_identity = locked_server_project_identity(server_path)
-            runtime_project = materialize_locked_server_project(
-                server_path,
-                identity=runtime_identity,
-            )
-            cmd = locked_server_command(runtime_project, entry_command)
-            child_environment["UV_PROJECT_ENVIRONMENT"] = str(
-                _locked_server_environment_path(
-                    server_path,
-                    project_sha256=runtime_identity["project_sha256"],
+    server_path = get_servers_path() / actual_dir
+    if server_path.exists():
+        _run_locked_local_server(server_path, entry_command, args, child_environment)
+        return
+
+    # Not in development: try to run the installed console script directly.
+    _run_child_command([entry_command, *args], entry_command, child_environment)
+
+
+def _run_locked_local_server(
+    server_path: Path,
+    entry_command: str,
+    args: tuple[str, ...],
+    child_environment: dict[str, str],
+) -> None:
+    """Build, evict, and launch one embedded server from its source-locked cache.
+
+    The root wheel ships each server's project and ``uv.lock``. The child runs
+    from an immutable, source-and-lock-keyed environment so the outer wheel binds
+    the child dependency closure exactly. After the environment for the current
+    spec is confirmed built, older specs of this server are evicted and the
+    private uv cache is pruned, keeping steady-state disk bounded to the newest
+    spec. The in-use marker is held across the whole launch so a concurrent
+    launch or ``cache gc`` never evicts the environment this process is using.
+    """
+    runtime_identity = locked_server_project_identity(server_path)
+    runtime_project = materialize_locked_server_project(
+        server_path,
+        identity=runtime_identity,
+    )
+    project_sha256 = runtime_identity["project_sha256"]
+    cache_root = _clio_cache_root()
+    environment_path = _locked_server_environment_path(
+        server_path,
+        project_sha256=project_sha256,
+    )
+    child_environment["UV_PROJECT_ENVIRONMENT"] = str(environment_path)
+    child_environment[LOCKED_SERVER_SCHEMA_ENV] = runtime_identity["schema_version"]
+    child_environment[LOCKED_SERVER_PROJECT_SHA_ENV] = project_sha256
+    child_environment[LOCKED_SERVER_LOCK_SHA_ENV] = runtime_identity["lock_sha256"]
+    child_environment["UV_CACHE_DIR"] = str((cache_root / "uv-cache").resolve())
+    child_environment.pop("VIRTUAL_ENV", None)
+
+    uv = uv_command()
+    try:
+        environment_path.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+    with EnvironmentInUseMarker(cache_root, environment_path.name):
+        if _build_locked_environment(uv, runtime_project, child_environment):
+            try:
+                maintain_after_build(
+                    cache_root,
+                    server_path.name,
+                    project_sha256=project_sha256,
+                    uv_executable=uv,
                 )
-            )
-            child_environment[LOCKED_SERVER_SCHEMA_ENV] = runtime_identity[
-                "schema_version"
-            ]
-            child_environment[LOCKED_SERVER_PROJECT_SHA_ENV] = runtime_identity[
-                "project_sha256"
-            ]
-            child_environment[LOCKED_SERVER_LOCK_SHA_ENV] = runtime_identity[
-                "lock_sha256"
-            ]
-            child_environment["UV_CACHE_DIR"] = str(
-                (_clio_cache_root() / "uv-cache").resolve()
-            )
-            child_environment.pop("VIRTUAL_ENV", None)
+            except Exception as exc:  # noqa: BLE001 - launch must never be blocked
+                default_event_emitter(
+                    {
+                        "event": "cache_maintenance_failed",
+                        "server": server_path.name,
+                        "reason": repr(exc),
+                    }
+                )
         else:
-            # Not in development, try to run the command directly (if installed)
-            cmd = [entry_command]
+            default_event_emitter(
+                {
+                    "event": "cache_maintenance_skipped",
+                    "server": server_path.name,
+                    "reason": "environment_build_failed",
+                }
+            )
+        cmd = locked_server_command(runtime_project, entry_command)
+        cmd.extend(args)
+        _run_child_command(cmd, entry_command, child_environment)
 
-    # Add any additional arguments
-    cmd.extend(args)
 
-    # Execute the command
+def _build_locked_environment(
+    uv: str,
+    runtime_project: Path,
+    child_environment: dict[str, str],
+) -> bool:
+    """Materialize the child environment for the current spec from its lock.
+
+    A discrete, frozen sync gives a verifiable "environment built" signal before
+    eviction removes any older spec, so a failed upgrade never destroys the
+    previously working environment. Its output is confined to stderr because the
+    child server's stdout is the JSON-RPC channel.
+    """
+    try:
+        completed = subprocess.run(
+            [
+                uv,
+                "sync",
+                "--no-dev",
+                "--no-editable",
+                "--frozen",
+                "--project",
+                str(runtime_project),
+            ],
+            env=child_environment,
+            capture_output=True,
+        )
+    except OSError:
+        return False
+    for stream in (completed.stdout, completed.stderr):
+        if stream:
+            sys.stderr.write(stream.decode("utf-8", errors="replace"))
+    sys.stderr.flush()
+    return completed.returncode == 0
+
+
+def _run_child_command(
+    cmd: list[str],
+    entry_command: str,
+    child_environment: dict[str, str],
+) -> None:
+    """Execute a child command, translating spawn failures to launcher errors."""
     try:
         subprocess.run(cmd, check=True, env=child_environment)
     except subprocess.CalledProcessError as e:
@@ -752,6 +844,108 @@ def search(args):
             "Error: uvx not found. Please install uv: https://github.com/astral-sh/uv"
         )
         sys.exit(1)
+
+
+@main.group("cache")
+def cache_group() -> None:
+    """Inspect and reclaim the private MCP runtime cache."""
+
+
+@cache_group.command("gc")
+@click.option(
+    "--keep",
+    type=int,
+    default=None,
+    help="Environments to keep per server (overrides CLIO_KIT_ENV_KEEP).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Report what would be evicted without deleting anything.",
+)
+def cache_gc(keep: int | None, dry_run: bool) -> None:
+    """Collapse every server to its newest N specs and prune the uv cache.
+
+    This is the manual reclaim path for a box already polluted by unbounded
+    environment history. It refuses to run while any environment is held by a
+    live server, because deleting an environment mid-spawn corrupts the cache.
+    """
+    cache_root = _clio_cache_root()
+    policy = load_cache_policy()
+    if keep is not None:
+        if keep < 1:
+            raise click.ClickException("--keep must be >= 1")
+        policy = dataclasses.replace(policy, keep_per_server=keep)
+    try:
+        eviction, prune = collect_cache_gc(
+            cache_root,
+            policy=policy,
+            uv_executable=uv_command(),
+            dry_run=dry_run,
+        )
+    except CacheInUseError as exc:
+        raise click.ClickException(str(exc)) from exc
+    budget = measure_cache_budget(cache_root, policy=policy)
+    click.echo(
+        json.dumps(
+            {
+                "dry_run": dry_run,
+                "keep_per_server": policy.keep_per_server,
+                "evicted": [
+                    {
+                        "server": entry.server,
+                        "hash_prefix": entry.hash_prefix,
+                        "bytes_freed": entry.bytes_freed,
+                    }
+                    for entry in eviction.evicted
+                ],
+                "skipped_in_use": [
+                    {"server": entry.server, "hash_prefix": entry.hash_prefix}
+                    for entry in eviction.skipped_in_use
+                ],
+                "bytes_freed": eviction.bytes_freed,
+                "uv_cache_prune": {
+                    "ran": prune.ran,
+                    "ok": prune.ok,
+                    "reason": prune.reason,
+                },
+                "cache_total_bytes": budget.total_bytes,
+                "over_budget": budget.over_budget,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+@cache_group.command("status")
+def cache_status() -> None:
+    """Print a machine-readable summary of the private runtime cache footprint."""
+    cache_root = _clio_cache_root()
+    policy = load_cache_policy()
+    budget = measure_cache_budget(cache_root, policy=policy)
+    environments_root = cache_root / "mcp-environments"
+    per_server: dict[str, int] = {}
+    if environments_root.is_dir():
+        for server in sorted(discover_servers(cache_root)):
+            token = f"{server}-"
+            per_server[server] = sum(
+                1
+                for child in environments_root.iterdir()
+                if child.is_dir() and child.name.startswith(token)
+            )
+    click.echo(
+        json.dumps(
+            {
+                "cache_root": str(cache_root),
+                "total_bytes": budget.total_bytes,
+                "max_bytes": budget.max_bytes,
+                "over_budget": budget.over_budget,
+                "keep_per_server": policy.keep_per_server,
+                "environments_per_server": per_server,
+            },
+            sort_keys=True,
+        )
+    )
 
 
 def cli():

--- a/src/clio_kit/env_cache.py
+++ b/src/clio_kit/env_cache.py
@@ -1,0 +1,843 @@
+"""Bounded lifecycle for the private MCP runtime cache.
+
+The launcher builds one source-and-lock addressed child environment per embedded
+server spec under ``mcp-environments`` and copies the server project under
+``mcp-projects``.  Because both trees are keyed by the project content hash, every
+version or lock change mints a *new* directory and the previous one is never
+reclaimed.  On a heavy-use box this grew to tens of gigabytes: 72 full virtual
+environments for 11 servers, each re-installing the same scientific stack, beside
+a private ``uv-cache`` that hoarded every wheel ever downloaded.
+
+This module turns that unbounded history into a bounded steady state.  After a
+server environment is *successfully* rebuilt for a new spec, the older specs of
+that same server are evicted (keep-newest-N), the private uv cache is pruned, and
+every deletion is reported as a typed structured event.  Eviction is safe: it
+never removes the environment just built, and it never removes an environment a
+live server process still holds through the in-use marker.  A ``cache gc``
+entrypoint applies the same invariant across all servers for boxes already
+polluted, refusing to run while any served process is alive.
+
+The one hard constraint the launcher imposes on this code: it runs *before* the
+child MCP server inherits stdout, which is the JSON-RPC channel.  Nothing here
+may write to stdout — every event and diagnostic goes to stderr.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Final
+
+CACHE_EVENT_SCHEMA: Final = "clio-kit.cache-event.v1"
+ENVIRONMENTS_DIRNAME: Final = "mcp-environments"
+PROJECTS_DIRNAME: Final = "mcp-projects"
+UV_CACHE_DIRNAME: Final = "uv-cache"
+LOCKS_DIRNAME: Final = ".locks"
+_ENV_HASH_PREFIX_LENGTH: Final = 24
+_HEX_DIGITS: Final = frozenset("0123456789abcdef")
+
+# Configuration environment variables. The launcher's established configuration
+# surface is process environment (see CLIO_KIT_CACHE_DIR), so these follow that
+# convention rather than inventing a settings file.
+KEEP_PER_SERVER_ENV: Final = "CLIO_KIT_ENV_KEEP"
+EVICTION_ENABLED_ENV: Final = "CLIO_KIT_ENV_EVICTION"
+PRUNE_ENABLED_ENV: Final = "CLIO_KIT_UV_CACHE_PRUNE"
+CACHE_MAX_BYTES_ENV: Final = "CLIO_KIT_CACHE_MAX_BYTES"
+_DEFAULT_KEEP_PER_SERVER: Final = 1
+
+EmitEvent = Callable[[Mapping[str, object]], None]
+
+
+def default_event_emitter(event: Mapping[str, object]) -> None:
+    """Emit one structured cache event to stderr as a sorted JSON line.
+
+    Stdout is reserved for the child server's JSON-RPC stream, so cache
+    telemetry is confined to stderr.
+    """
+    payload = {"schema_version": CACHE_EVENT_SCHEMA, **event}
+    sys.stderr.write(json.dumps(payload, sort_keys=True) + "\n")
+    sys.stderr.flush()
+
+
+@dataclass(frozen=True)
+class CachePolicy:
+    """Resolved, typed bounds for the private MCP runtime cache."""
+
+    keep_per_server: int
+    eviction_enabled: bool
+    prune_enabled: bool
+    max_cache_bytes: int | None
+
+    @property
+    def evict_count(self) -> int:
+        """Return how many older specs, beyond the current, may be retained."""
+        return max(0, self.keep_per_server - 1)
+
+
+@dataclass(frozen=True)
+class EvictedEnvironment:
+    """One evicted server spec and the reclaimed footprint it represented."""
+
+    server: str
+    hash_prefix: str
+    reason: str
+    bytes_freed: int
+    paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SkippedEnvironment:
+    """One retained-or-skipped spec, with the typed reason it was not evicted."""
+
+    server: str
+    hash_prefix: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class EvictionReport:
+    """Structured outcome of a keep-newest eviction pass for a server set."""
+
+    kept: tuple[SkippedEnvironment, ...] = ()
+    evicted: tuple[EvictedEnvironment, ...] = ()
+    skipped_in_use: tuple[SkippedEnvironment, ...] = ()
+
+    @property
+    def bytes_freed(self) -> int:
+        """Return total bytes reclaimed across every evicted spec."""
+        return sum(entry.bytes_freed for entry in self.evicted)
+
+
+@dataclass(frozen=True)
+class PruneReport:
+    """Structured outcome of a private ``uv cache prune`` invocation."""
+
+    ran: bool
+    ok: bool
+    reason: str
+    cache_dir: str
+
+
+@dataclass(frozen=True)
+class BudgetReport:
+    """Measured cache footprint against the optional configured budget."""
+
+    total_bytes: int
+    max_bytes: int | None
+    over_budget: bool
+
+
+@dataclass
+class _EnvIdentity:
+    """One server spec observed across the environment and project trees."""
+
+    server: str
+    hash_prefix: str
+    env_dir: Path | None = None
+    project_dirs: list[Path] = field(default_factory=list)
+
+    def all_paths(self) -> list[Path]:
+        paths: list[Path] = []
+        if self.env_dir is not None:
+            paths.append(self.env_dir)
+        paths.extend(self.project_dirs)
+        return paths
+
+    def recency(self) -> float:
+        """Return the newest mtime across this spec's on-disk directories."""
+        times = [_safe_mtime(path) for path in self.all_paths()]
+        return max(times) if times else 0.0
+
+
+def load_cache_policy(
+    environ: Mapping[str, str] | None = None,
+    *,
+    emit: EmitEvent = default_event_emitter,
+) -> CachePolicy:
+    """Resolve the cache policy from configuration, reporting invalid values.
+
+    Invalid configuration is never silently corrected: each rejected value emits
+    a typed ``cache_config_rejected`` event before the documented default is used.
+    """
+    env = os.environ if environ is None else environ
+    keep = _positive_int_config(
+        env.get(KEEP_PER_SERVER_ENV),
+        default=_DEFAULT_KEEP_PER_SERVER,
+        name=KEEP_PER_SERVER_ENV,
+        emit=emit,
+    )
+    max_bytes = _optional_positive_int_config(
+        env.get(CACHE_MAX_BYTES_ENV),
+        name=CACHE_MAX_BYTES_ENV,
+        emit=emit,
+    )
+    return CachePolicy(
+        keep_per_server=keep,
+        eviction_enabled=_bool_config(env.get(EVICTION_ENABLED_ENV), default=True),
+        prune_enabled=_bool_config(env.get(PRUNE_ENABLED_ENV), default=True),
+        max_cache_bytes=max_bytes,
+    )
+
+
+def evict_superseded_environments(
+    cache_root: Path,
+    server: str,
+    *,
+    keep_current: str,
+    policy: CachePolicy,
+    emit: EmitEvent = default_event_emitter,
+) -> EvictionReport:
+    """Evict older specs of one server, keeping the current build and newest N.
+
+    ``keep_current`` is the full ``project_sha256`` of the environment that was
+    just built; it is retained unconditionally so a launch never deletes the
+    environment it is about to run.  Additional specs up to the configured
+    keep-count are retained by recency.  Any remaining spec that a live server
+    still holds is skipped with a typed reason rather than deleted, because
+    concurrent mutation of an in-use environment corrupts it.
+    """
+    if not policy.eviction_enabled:
+        return EvictionReport(
+            skipped_in_use=(),
+            kept=(
+                SkippedEnvironment(
+                    server, keep_current[:_ENV_HASH_PREFIX_LENGTH], "eviction_disabled"
+                ),
+            ),
+        )
+
+    current_prefix = keep_current[:_ENV_HASH_PREFIX_LENGTH]
+    identities = _discover_identities(cache_root, server)
+    return _apply_keep_newest(
+        cache_root,
+        identities,
+        retain_prefixes={current_prefix},
+        keep_extra=policy.evict_count,
+        reason="superseded",
+        emit=emit,
+    )
+
+
+def prune_uv_cache(
+    cache_root: Path,
+    *,
+    policy: CachePolicy,
+    uv_executable: str,
+    emit: EmitEvent = default_event_emitter,
+    run: Callable[..., subprocess.CompletedProcess[bytes]] | None = None,
+) -> PruneReport:
+    """Prune the private uv cache so wheel retention tracks live environments.
+
+    Failure is tolerated: the launch must proceed even when pruning cannot run,
+    and every outcome — skipped, pruned, or failed — is reported as a typed
+    event with its reason.
+    """
+    run_command = subprocess.run if run is None else run
+    cache_dir = (cache_root / UV_CACHE_DIRNAME).resolve()
+    if not policy.prune_enabled:
+        report = PruneReport(
+            ran=False, ok=True, reason="prune_disabled", cache_dir=str(cache_dir)
+        )
+        emit(
+            {
+                "event": "uv_cache_prune",
+                "ran": False,
+                "ok": True,
+                "reason": report.reason,
+                "cache_dir": report.cache_dir,
+            }
+        )
+        return report
+    if not cache_dir.is_dir():
+        report = PruneReport(
+            ran=False, ok=True, reason="cache_absent", cache_dir=str(cache_dir)
+        )
+        emit(
+            {
+                "event": "uv_cache_prune",
+                "ran": False,
+                "ok": True,
+                "reason": report.reason,
+                "cache_dir": report.cache_dir,
+            }
+        )
+        return report
+    try:
+        completed = run_command(
+            [uv_executable, "cache", "prune", "--cache-dir", str(cache_dir)],
+            capture_output=True,
+            check=False,
+        )
+    except OSError as exc:
+        report = PruneReport(
+            ran=True,
+            ok=False,
+            reason=f"prune_spawn_failed: {exc}",
+            cache_dir=str(cache_dir),
+        )
+        emit(
+            {
+                "event": "uv_cache_prune",
+                "ran": True,
+                "ok": False,
+                "reason": report.reason,
+                "cache_dir": report.cache_dir,
+            }
+        )
+        return report
+    if completed.returncode != 0:
+        detail = _decode_stream_tail(completed.stderr) or _decode_stream_tail(
+            completed.stdout
+        )
+        report = PruneReport(
+            ran=True,
+            ok=False,
+            reason=f"prune_exit_{completed.returncode}: {detail}".strip(),
+            cache_dir=str(cache_dir),
+        )
+        emit(
+            {
+                "event": "uv_cache_prune",
+                "ran": True,
+                "ok": False,
+                "reason": report.reason,
+                "cache_dir": report.cache_dir,
+            }
+        )
+        return report
+    report = PruneReport(ran=True, ok=True, reason="pruned", cache_dir=str(cache_dir))
+    emit(
+        {
+            "event": "uv_cache_prune",
+            "ran": True,
+            "ok": True,
+            "reason": report.reason,
+            "cache_dir": report.cache_dir,
+        }
+    )
+    return report
+
+
+def measure_cache_budget(
+    cache_root: Path,
+    *,
+    policy: CachePolicy,
+    emit: EmitEvent = default_event_emitter,
+) -> BudgetReport:
+    """Measure the cache footprint and report a typed over-budget event.
+
+    The bound is advisory: uv owns wheel pruning, so this asserts the invariant
+    for monitoring and CI rather than deleting arbitrary cache entries.
+    """
+    total = _dir_size(cache_root)
+    over = policy.max_cache_bytes is not None and total > policy.max_cache_bytes
+    if over:
+        emit(
+            {
+                "event": "cache_over_budget",
+                "cache_root": str(cache_root),
+                "total_bytes": total,
+                "max_bytes": policy.max_cache_bytes,
+            }
+        )
+    return BudgetReport(
+        total_bytes=total, max_bytes=policy.max_cache_bytes, over_budget=over
+    )
+
+
+def maintain_after_build(
+    cache_root: Path,
+    server: str,
+    *,
+    project_sha256: str,
+    uv_executable: str,
+    policy: CachePolicy | None = None,
+    emit: EmitEvent = default_event_emitter,
+) -> tuple[EvictionReport, PruneReport, BudgetReport]:
+    """Run the full post-build steady-state pass: evict, prune, measure.
+
+    This is the single entry point the launcher calls after a server's
+    environment is confirmed built.  Every step is best-effort with a typed
+    report; a maintenance failure must never prevent the server from launching.
+    """
+    resolved_policy = policy or load_cache_policy(emit=emit)
+    eviction = evict_superseded_environments(
+        cache_root,
+        server,
+        keep_current=project_sha256,
+        policy=resolved_policy,
+        emit=emit,
+    )
+    prune = prune_uv_cache(
+        cache_root,
+        policy=resolved_policy,
+        uv_executable=uv_executable,
+        emit=emit,
+    )
+    budget = measure_cache_budget(cache_root, policy=resolved_policy, emit=emit)
+    return eviction, prune, budget
+
+
+class CacheInUseError(RuntimeError):
+    """Raised when a bulk cache operation is refused because a server is live."""
+
+
+def collect_cache_gc(
+    cache_root: Path,
+    *,
+    policy: CachePolicy,
+    uv_executable: str,
+    emit: EmitEvent = default_event_emitter,
+    dry_run: bool = False,
+) -> tuple[EvictionReport, PruneReport]:
+    """Apply keep-newest-N across every server for an already-polluted box.
+
+    This mirrors the per-launch invariant but has no "current build" to anchor
+    on, so it keeps the newest N specs per server by recency.  It refuses (typed)
+    to touch anything while any environment is still held by a live server,
+    because bulk deletion during an active spawn corrupts the cache.
+    """
+    servers = discover_servers(cache_root)
+    live = [
+        identity
+        for identity in _all_identities(cache_root, servers)
+        if _identity_in_use(cache_root, identity)
+    ]
+    if live:
+        held = sorted(f"{item.server}-{item.hash_prefix}" for item in live)
+        emit(
+            {
+                "event": "cache_gc_refused",
+                "reason": "environments_in_use",
+                "in_use": held,
+            }
+        )
+        raise CacheInUseError(
+            "refusing cache gc while these environments are in use: " + ", ".join(held)
+        )
+
+    aggregate = EvictionReport()
+    for server in sorted(servers):
+        identities = _discover_identities(cache_root, server)
+        report = _apply_keep_newest(
+            cache_root,
+            identities,
+            retain_prefixes=set(),
+            keep_extra=max(0, policy.keep_per_server),
+            reason="gc_superseded",
+            emit=emit,
+            dry_run=dry_run,
+        )
+        aggregate = _merge_reports(aggregate, report)
+
+    if dry_run:
+        prune = PruneReport(
+            ran=False,
+            ok=True,
+            reason="dry_run",
+            cache_dir=str((cache_root / UV_CACHE_DIRNAME).resolve()),
+        )
+        emit(
+            {
+                "event": "uv_cache_prune",
+                "ran": False,
+                "ok": True,
+                "reason": prune.reason,
+                "cache_dir": prune.cache_dir,
+            }
+        )
+    else:
+        prune = prune_uv_cache(
+            cache_root, policy=policy, uv_executable=uv_executable, emit=emit
+        )
+    return aggregate, prune
+
+
+def discover_servers(cache_root: Path) -> set[str]:
+    """Return every server name known to the on-disk project and env trees."""
+    servers: set[str] = set()
+    projects_root = cache_root / PROJECTS_DIRNAME
+    if projects_root.is_dir():
+        servers.update(
+            child.name for child in projects_root.iterdir() if child.is_dir()
+        )
+    return servers
+
+
+# --- in-use marker -------------------------------------------------------
+
+
+class EnvironmentInUseMarker:
+    """A per-process lock proving a live launcher holds one environment.
+
+    The marker is a lock file named for the holding process id under a locks
+    registry sibling to the environment tree.  Concurrent launches of the same
+    spec never contend, because each locks only its own pid file; a checker
+    detecting *any* pid file it cannot lock knows a live holder exists, while a
+    crashed holder's file is lockable and reclaimed.  The registry lives outside
+    the environment directory so acquiring it never perturbs environment mtimes
+    or the environment contents uv manages.
+    """
+
+    def __init__(self, cache_root: Path, env_dir_name: str) -> None:
+        self._lock_dir = _locks_dir(cache_root, env_dir_name)
+        self._handle: _FileLock | None = None
+
+    def __enter__(self) -> "EnvironmentInUseMarker":
+        try:
+            self._lock_dir.mkdir(parents=True, exist_ok=True)
+            lock_path = self._lock_dir / f"{os.getpid()}.lock"
+            handle = _FileLock(lock_path)
+            handle.acquire()
+            self._handle = handle
+        except OSError:
+            # Best-effort: an unwritable registry must not block a launch. The
+            # current environment is never a deletion candidate regardless.
+            self._handle = None
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._handle is not None:
+            self._handle.release()
+            self._handle = None
+
+
+def _identity_in_use(cache_root: Path, identity: _EnvIdentity) -> bool:
+    env_dir_name = (
+        identity.env_dir.name
+        if identity.env_dir is not None
+        else f"{identity.server}-{identity.hash_prefix}"
+    )
+    return _env_dir_in_use(cache_root, env_dir_name)
+
+
+def _env_dir_in_use(cache_root: Path, env_dir_name: str) -> bool:
+    """Return whether any live launcher currently holds this environment."""
+    lock_dir = _locks_dir(cache_root, env_dir_name)
+    if not lock_dir.is_dir():
+        return False
+    in_use = False
+    for lock_path in lock_dir.glob("*.lock"):
+        probe = _FileLock(lock_path)
+        if probe.try_acquire():
+            # No live holder: reclaim the stale marker.
+            probe.release()
+            try:
+                lock_path.unlink()
+            except OSError:
+                pass
+        else:
+            in_use = True
+    return in_use
+
+
+def _locks_dir(cache_root: Path, env_dir_name: str) -> Path:
+    return cache_root / ENVIRONMENTS_DIRNAME / LOCKS_DIRNAME / env_dir_name
+
+
+class _FileLock:
+    """A cross-platform advisory lock on a single sentinel file."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._fd: int | None = None
+
+    def acquire(self) -> None:
+        if not self.try_acquire():
+            raise OSError(f"could not acquire lock: {self._path}")
+
+    def try_acquire(self) -> bool:
+        fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o644)
+        try:
+            os.write(fd, b"\0")
+            os.lseek(fd, 0, os.SEEK_SET)
+            _lock_region(fd)
+        except OSError:
+            os.close(fd)
+            return False
+        self._fd = fd
+        return True
+
+    def release(self) -> None:
+        if self._fd is None:
+            return
+        try:
+            _unlock_region(self._fd)
+        except OSError:
+            pass
+        finally:
+            os.close(self._fd)
+            self._fd = None
+
+
+if sys.platform == "win32":
+    import msvcrt
+
+    def _lock_region(fd: int) -> None:
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+
+    def _unlock_region(fd: int) -> None:
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+else:
+    import fcntl
+
+    def _lock_region(fd: int) -> None:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def _unlock_region(fd: int) -> None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+# --- internals -----------------------------------------------------------
+
+
+def _apply_keep_newest(
+    cache_root: Path,
+    identities: Sequence[_EnvIdentity],
+    *,
+    retain_prefixes: set[str],
+    keep_extra: int,
+    reason: str,
+    emit: EmitEvent,
+    dry_run: bool = False,
+) -> EvictionReport:
+    """Retain forced + newest specs; evict the rest, skipping in-use ones."""
+    forced = [item for item in identities if item.hash_prefix in retain_prefixes]
+    others = sorted(
+        (item for item in identities if item.hash_prefix not in retain_prefixes),
+        key=lambda item: item.recency(),
+        reverse=True,
+    )
+    retained = forced + others[:keep_extra]
+    candidates = others[keep_extra:]
+
+    kept = tuple(
+        SkippedEnvironment(item.server, item.hash_prefix, "retained")
+        for item in retained
+    )
+    evicted: list[EvictedEnvironment] = []
+    skipped: list[SkippedEnvironment] = []
+    for identity in candidates:
+        if _identity_in_use(cache_root, identity):
+            skipped.append(
+                SkippedEnvironment(identity.server, identity.hash_prefix, "in_use")
+            )
+            emit(
+                {
+                    "event": "env_evict_skipped",
+                    "server": identity.server,
+                    "hash_prefix": identity.hash_prefix,
+                    "reason": "in_use",
+                }
+            )
+            continue
+        paths = identity.all_paths()
+        freed = sum(_dir_size(path) for path in paths)
+        if not dry_run:
+            for path in paths:
+                _remove_tree(path)
+            _remove_tree(
+                _locks_dir(cache_root, f"{identity.server}-{identity.hash_prefix}")
+            )
+        evicted.append(
+            EvictedEnvironment(
+                server=identity.server,
+                hash_prefix=identity.hash_prefix,
+                reason=reason,
+                bytes_freed=freed,
+                paths=tuple(str(path) for path in paths),
+            )
+        )
+        emit(
+            {
+                "event": "env_evicted",
+                "server": identity.server,
+                "hash_prefix": identity.hash_prefix,
+                "reason": reason,
+                "bytes_freed": freed,
+                "paths": [str(path) for path in paths],
+                "dry_run": dry_run,
+            }
+        )
+    return EvictionReport(
+        kept=kept, evicted=tuple(evicted), skipped_in_use=tuple(skipped)
+    )
+
+
+def _discover_identities(cache_root: Path, server: str) -> list[_EnvIdentity]:
+    """Group one server's specs across the environment and project trees."""
+    by_prefix: dict[str, _EnvIdentity] = {}
+
+    def identity_for(prefix: str) -> _EnvIdentity:
+        existing = by_prefix.get(prefix)
+        if existing is None:
+            existing = _EnvIdentity(server=server, hash_prefix=prefix)
+            by_prefix[prefix] = existing
+        return existing
+
+    env_root = cache_root / ENVIRONMENTS_DIRNAME
+    if env_root.is_dir():
+        prefix_token = f"{server}-"
+        for child in env_root.iterdir():
+            if child.name == LOCKS_DIRNAME or not child.is_dir():
+                continue
+            if not child.name.startswith(prefix_token):
+                continue
+            remainder = child.name[len(prefix_token) :]
+            if _is_env_hash_prefix(remainder):
+                identity_for(remainder).env_dir = child
+
+    project_root = cache_root / PROJECTS_DIRNAME / server
+    if project_root.is_dir():
+        for child in project_root.iterdir():
+            if not child.is_dir():
+                continue
+            if len(child.name) >= _ENV_HASH_PREFIX_LENGTH and _is_hex(child.name):
+                identity_for(child.name[:_ENV_HASH_PREFIX_LENGTH]).project_dirs.append(
+                    child
+                )
+
+    return list(by_prefix.values())
+
+
+def _all_identities(cache_root: Path, servers: Iterable[str]) -> list[_EnvIdentity]:
+    identities: list[_EnvIdentity] = []
+    for server in servers:
+        identities.extend(_discover_identities(cache_root, server))
+    return identities
+
+
+def _merge_reports(left: EvictionReport, right: EvictionReport) -> EvictionReport:
+    return EvictionReport(
+        kept=left.kept + right.kept,
+        evicted=left.evicted + right.evicted,
+        skipped_in_use=left.skipped_in_use + right.skipped_in_use,
+    )
+
+
+def _is_env_hash_prefix(value: str) -> bool:
+    return len(value) == _ENV_HASH_PREFIX_LENGTH and _is_hex(value)
+
+
+def _is_hex(value: str) -> bool:
+    return bool(value) and all(character in _HEX_DIGITS for character in value)
+
+
+def _safe_mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _dir_size(path: Path) -> int:
+    if not path.exists():
+        return 0
+    total = 0
+    for current_root, _dirs, files in os.walk(path):
+        base = Path(current_root)
+        for name in files:
+            try:
+                total += (base / name).stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def _remove_tree(path: Path) -> None:
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def _decode_stream_tail(data: bytes | None, *, limit: int = 2_000) -> str:
+    if not data:
+        return ""
+    return data[-limit:].decode("utf-8", errors="replace").strip()
+
+
+def _positive_int_config(
+    raw: str | None,
+    *,
+    default: int,
+    name: str,
+    emit: EmitEvent,
+) -> int:
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        emit(
+            {
+                "event": "cache_config_rejected",
+                "name": name,
+                "value": raw,
+                "reason": "not_an_integer",
+                "using_default": default,
+            }
+        )
+        return default
+    if value < 1:
+        emit(
+            {
+                "event": "cache_config_rejected",
+                "name": name,
+                "value": raw,
+                "reason": "below_minimum",
+                "using_default": default,
+            }
+        )
+        return default
+    return value
+
+
+def _optional_positive_int_config(
+    raw: str | None,
+    *,
+    name: str,
+    emit: EmitEvent,
+) -> int | None:
+    if raw is None or raw.strip() == "":
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        emit(
+            {
+                "event": "cache_config_rejected",
+                "name": name,
+                "value": raw,
+                "reason": "not_an_integer",
+                "using_default": None,
+            }
+        )
+        return None
+    if value < 1:
+        emit(
+            {
+                "event": "cache_config_rejected",
+                "name": name,
+                "value": raw,
+                "reason": "below_minimum",
+                "using_default": None,
+            }
+        )
+        return None
+    return value
+
+
+def _bool_config(raw: str | None, *, default: bool) -> bool:
+    if raw is None or raw.strip() == "":
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return default

--- a/tests/test_env_cache.py
+++ b/tests/test_env_cache.py
@@ -1,0 +1,433 @@
+"""Tests for the bounded MCP runtime cache lifecycle (issue #334)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import clio_kit
+from clio_kit.env_cache import (
+    CacheInUseError,
+    CachePolicy,
+    EnvironmentInUseMarker,
+    collect_cache_gc,
+    evict_superseded_environments,
+    load_cache_policy,
+    maintain_after_build,
+    measure_cache_budget,
+    prune_uv_cache,
+)
+
+# A deterministic pool of 64-hex-char project hashes. Only the first 24 chars
+# name the environment directory, so the fixtures keep distinct prefixes.
+_HASHES = [f"{index:02x}" + "a" * 62 for index in range(1, 10)]
+
+
+def _policy(**overrides: Any) -> CachePolicy:
+    base = {
+        "keep_per_server": 1,
+        "eviction_enabled": True,
+        "prune_enabled": True,
+        "max_cache_bytes": None,
+    }
+    base.update(overrides)
+    return CachePolicy(**base)  # type: ignore[arg-type]
+
+
+def _seed_spec(
+    cache_root: Path,
+    server: str,
+    full_hash: str,
+    *,
+    mtime: float,
+    env_bytes: int = 4096,
+) -> tuple[Path, Path]:
+    """Create the environment and project directories for one server spec."""
+    env_dir = cache_root / "mcp-environments" / f"{server}-{full_hash[:24]}"
+    project_dir = cache_root / "mcp-projects" / server / full_hash
+    (env_dir / "bin").mkdir(parents=True, exist_ok=True)
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (env_dir / "bin" / "python").write_bytes(b"x" * env_bytes)
+    (project_dir / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    for target in (env_dir, project_dir):
+        os.utime(target, (mtime, mtime))
+    return env_dir, project_dir
+
+
+def _events_collector() -> tuple[list[dict[str, Any]], Any]:
+    events: list[dict[str, Any]] = []
+
+    def emit(event: Any) -> None:
+        events.append(dict(event))
+
+    return events, emit
+
+
+def test_build_next_spec_evicts_previous_keeping_newest(tmp_path: Path) -> None:
+    """Building spec N+1 must evict spec N when keep-per-server is 1."""
+    events, emit = _events_collector()
+    old_env, old_project = _seed_spec(tmp_path, "spack", _HASHES[0], mtime=1_000.0)
+    new_env, new_project = _seed_spec(tmp_path, "spack", _HASHES[1], mtime=2_000.0)
+
+    report = evict_superseded_environments(
+        tmp_path,
+        "spack",
+        keep_current=_HASHES[1],
+        policy=_policy(keep_per_server=1),
+        emit=emit,
+    )
+
+    assert not old_env.exists()
+    assert not old_project.exists()
+    assert new_env.exists()
+    assert new_project.exists()
+    assert [entry.hash_prefix for entry in report.evicted] == [_HASHES[0][:24]]
+    assert report.bytes_freed > 0
+    assert any(
+        event["event"] == "env_evicted" and event["reason"] == "superseded"
+        for event in events
+    )
+
+
+def test_keep_n_knob_retains_that_many_specs(tmp_path: Path) -> None:
+    """A keep-per-server of 2 must retain the current build plus one newest spec."""
+    old_env, _ = _seed_spec(tmp_path, "jarvis", _HASHES[0], mtime=1_000.0)
+    mid_env, _ = _seed_spec(tmp_path, "jarvis", _HASHES[1], mtime=2_000.0)
+    new_env, _ = _seed_spec(tmp_path, "jarvis", _HASHES[2], mtime=3_000.0)
+
+    report = evict_superseded_environments(
+        tmp_path,
+        "jarvis",
+        keep_current=_HASHES[2],
+        policy=_policy(keep_per_server=2),
+        emit=lambda _event: None,
+    )
+
+    assert new_env.exists()  # current build
+    assert mid_env.exists()  # newest of the remainder
+    assert not old_env.exists()  # oldest evicted
+    assert [entry.hash_prefix for entry in report.evicted] == [_HASHES[0][:24]]
+
+
+def test_disabled_eviction_retains_all_specs(tmp_path: Path) -> None:
+    """The sabotage twin: disabling eviction must leave every stale spec on disk.
+
+    This proves the keep-newest tests are load-bearing — if eviction silently
+    became a no-op, ``test_build_next_spec_evicts_previous`` would fail while this
+    test would pass, so the pair pins the real behavior in both directions.
+    """
+    old_env, old_project = _seed_spec(tmp_path, "spack", _HASHES[0], mtime=1_000.0)
+    _seed_spec(tmp_path, "spack", _HASHES[1], mtime=2_000.0)
+
+    report = evict_superseded_environments(
+        tmp_path,
+        "spack",
+        keep_current=_HASHES[1],
+        policy=_policy(eviction_enabled=False),
+        emit=lambda _event: None,
+    )
+
+    assert old_env.exists()
+    assert old_project.exists()
+    assert report.evicted == ()
+
+
+def test_in_use_environment_is_skipped_with_typed_reason(tmp_path: Path) -> None:
+    """An environment held by a live launcher must be skipped, not deleted."""
+    events, emit = _events_collector()
+    old_env, old_project = _seed_spec(tmp_path, "slurm", _HASHES[0], mtime=1_000.0)
+    _seed_spec(tmp_path, "slurm", _HASHES[1], mtime=2_000.0)
+
+    with EnvironmentInUseMarker(tmp_path, old_env.name):
+        report = evict_superseded_environments(
+            tmp_path,
+            "slurm",
+            keep_current=_HASHES[1],
+            policy=_policy(keep_per_server=1),
+            emit=emit,
+        )
+
+    assert old_env.exists()
+    assert old_project.exists()
+    assert report.evicted == ()
+    assert [entry.reason for entry in report.skipped_in_use] == ["in_use"]
+    assert any(
+        event["event"] == "env_evict_skipped" and event["reason"] == "in_use"
+        for event in events
+    )
+
+
+def test_released_marker_no_longer_blocks_eviction(tmp_path: Path) -> None:
+    """Once a holder exits, its environment becomes a normal eviction candidate."""
+    old_env, _ = _seed_spec(tmp_path, "slurm", _HASHES[0], mtime=1_000.0)
+    _seed_spec(tmp_path, "slurm", _HASHES[1], mtime=2_000.0)
+
+    with EnvironmentInUseMarker(tmp_path, old_env.name):
+        pass  # acquire then release
+
+    report = evict_superseded_environments(
+        tmp_path,
+        "slurm",
+        keep_current=_HASHES[1],
+        policy=_policy(keep_per_server=1),
+        emit=lambda _event: None,
+    )
+
+    assert not old_env.exists()
+    assert [entry.hash_prefix for entry in report.evicted] == [_HASHES[0][:24]]
+
+
+def test_prune_invoked_on_success(tmp_path: Path) -> None:
+    """A successful prune must be reported as run and ok with a typed event."""
+    (tmp_path / "uv-cache").mkdir(parents=True)
+    events, emit = _events_collector()
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+    report = prune_uv_cache(
+        tmp_path,
+        policy=_policy(),
+        uv_executable="uv",
+        emit=emit,
+        run=fake_run,
+    )
+
+    assert report.ran and report.ok
+    assert calls and calls[0][:3] == ["uv", "cache", "prune"]
+    assert any(event["event"] == "uv_cache_prune" and event["ok"] for event in events)
+
+
+def test_prune_failure_is_tolerated_with_reason(tmp_path: Path) -> None:
+    """A non-zero prune exit must be tolerated and reported, never raised."""
+    (tmp_path / "uv-cache").mkdir(parents=True)
+    events, emit = _events_collector()
+
+    def failing_run(
+        cmd: list[str], **_kwargs: Any
+    ) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.CompletedProcess(cmd, 3, b"", b"disk error")
+
+    report = prune_uv_cache(
+        tmp_path,
+        policy=_policy(),
+        uv_executable="uv",
+        emit=emit,
+        run=failing_run,
+    )
+
+    assert report.ran and not report.ok
+    assert "prune_exit_3" in report.reason
+    assert any(
+        event["event"] == "uv_cache_prune" and not event["ok"] for event in events
+    )
+
+
+def test_prune_spawn_failure_is_tolerated(tmp_path: Path) -> None:
+    """A missing uv binary during prune must not raise out of maintenance."""
+    (tmp_path / "uv-cache").mkdir(parents=True)
+
+    def raising_run(cmd: list[str], **_kwargs: Any) -> Any:
+        raise OSError("uv not found")
+
+    report = prune_uv_cache(
+        tmp_path,
+        policy=_policy(),
+        uv_executable="uv",
+        emit=lambda _event: None,
+        run=raising_run,
+    )
+
+    assert report.ran and not report.ok
+    assert "prune_spawn_failed" in report.reason
+
+
+def test_gc_refuses_when_any_environment_is_in_use(tmp_path: Path) -> None:
+    """Bulk gc must refuse entirely while any environment is held, deleting none."""
+    events, emit = _events_collector()
+    held_env, _ = _seed_spec(tmp_path, "spack", _HASHES[0], mtime=1_000.0)
+    other_env, _ = _seed_spec(tmp_path, "spack", _HASHES[1], mtime=2_000.0)
+
+    with EnvironmentInUseMarker(tmp_path, held_env.name):
+        with pytest.raises(CacheInUseError):
+            collect_cache_gc(
+                tmp_path,
+                policy=_policy(keep_per_server=1),
+                uv_executable="uv",
+                emit=emit,
+            )
+
+    assert held_env.exists()
+    assert other_env.exists()
+    assert any(event["event"] == "cache_gc_refused" for event in events)
+
+
+def test_gc_collapses_every_server_to_keep_n(tmp_path: Path) -> None:
+    """With nothing in use, gc must collapse each server to its newest N specs."""
+    spack_old, _ = _seed_spec(tmp_path, "spack", _HASHES[0], mtime=1_000.0)
+    spack_new, _ = _seed_spec(tmp_path, "spack", _HASHES[1], mtime=2_000.0)
+    jarvis_old, _ = _seed_spec(tmp_path, "jarvis", _HASHES[2], mtime=1_500.0)
+    jarvis_new, _ = _seed_spec(tmp_path, "jarvis", _HASHES[3], mtime=2_500.0)
+    (tmp_path / "uv-cache").mkdir(parents=True)
+
+    eviction, prune = collect_cache_gc(
+        tmp_path,
+        policy=_policy(keep_per_server=1),
+        uv_executable="uv",
+        emit=lambda _event: None,
+        dry_run=False,
+    )
+
+    assert spack_new.exists() and jarvis_new.exists()
+    assert not spack_old.exists() and not jarvis_old.exists()
+    assert {entry.server for entry in eviction.evicted} == {"spack", "jarvis"}
+    # prune is attempted against the real uv; tolerate whatever the box reports.
+    assert prune.ran or prune.reason in {"cache_absent", "prune_disabled"}
+
+
+def test_gc_dry_run_reports_without_deleting(tmp_path: Path) -> None:
+    """A dry-run gc must enumerate eviction candidates but delete nothing."""
+    old_env, _ = _seed_spec(tmp_path, "spack", _HASHES[0], mtime=1_000.0)
+    _seed_spec(tmp_path, "spack", _HASHES[1], mtime=2_000.0)
+
+    eviction, prune = collect_cache_gc(
+        tmp_path,
+        policy=_policy(keep_per_server=1),
+        uv_executable="uv",
+        emit=lambda _event: None,
+        dry_run=True,
+    )
+
+    assert old_env.exists()  # nothing removed
+    assert [entry.hash_prefix for entry in eviction.evicted] == [_HASHES[0][:24]]
+    assert not prune.ran and prune.reason == "dry_run"
+
+
+def test_load_cache_policy_reads_configuration(tmp_path: Path) -> None:
+    """Configuration knobs must be honored from the process environment."""
+    policy = load_cache_policy(
+        {
+            "CLIO_KIT_ENV_KEEP": "3",
+            "CLIO_KIT_ENV_EVICTION": "0",
+            "CLIO_KIT_UV_CACHE_PRUNE": "off",
+            "CLIO_KIT_CACHE_MAX_BYTES": "1048576",
+        },
+        emit=lambda _event: None,
+    )
+
+    assert policy.keep_per_server == 3
+    assert policy.eviction_enabled is False
+    assert policy.prune_enabled is False
+    assert policy.max_cache_bytes == 1_048_576
+
+
+def test_load_cache_policy_rejects_invalid_values_typed() -> None:
+    """Invalid knobs must fall back to defaults with a typed rejection event."""
+    events, emit = _events_collector()
+
+    policy = load_cache_policy(
+        {"CLIO_KIT_ENV_KEEP": "0", "CLIO_KIT_CACHE_MAX_BYTES": "huge"},
+        emit=emit,
+    )
+
+    assert policy.keep_per_server == 1  # default
+    assert policy.max_cache_bytes is None
+    reasons = {
+        (event["name"], event["reason"])
+        for event in events
+        if event["event"] == "cache_config_rejected"
+    }
+    assert ("CLIO_KIT_ENV_KEEP", "below_minimum") in reasons
+    assert ("CLIO_KIT_CACHE_MAX_BYTES", "not_an_integer") in reasons
+
+
+def test_measure_cache_budget_flags_over_budget(tmp_path: Path) -> None:
+    """The advisory budget must emit a typed over-budget event when exceeded."""
+    events, emit = _events_collector()
+    _seed_spec(tmp_path, "spack", _HASHES[0], mtime=1_000.0, env_bytes=8192)
+
+    report = measure_cache_budget(
+        tmp_path, policy=_policy(max_cache_bytes=1), emit=emit
+    )
+
+    assert report.over_budget
+    assert report.total_bytes >= 8192
+    assert any(event["event"] == "cache_over_budget" for event in events)
+
+
+def test_maintain_after_build_evicts_and_prunes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The post-build pass must evict stale specs and attempt a prune together."""
+    (tmp_path / "uv-cache").mkdir(parents=True)
+    old_env, _ = _seed_spec(tmp_path, "spack", _HASHES[0], mtime=1_000.0)
+    _seed_spec(tmp_path, "spack", _HASHES[1], mtime=2_000.0)
+    prune_calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        prune_calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+    monkeypatch.setattr("clio_kit.env_cache.subprocess.run", fake_run)
+
+    eviction, prune, budget = maintain_after_build(
+        tmp_path,
+        "spack",
+        project_sha256=_HASHES[1],
+        uv_executable="uv",
+        policy=_policy(keep_per_server=1),
+        emit=lambda _event: None,
+    )
+
+    assert not old_env.exists()
+    assert eviction.bytes_freed > 0
+    assert prune.ran and prune.ok
+    assert prune_calls and prune_calls[0][1:3] == ["cache", "prune"]
+    assert budget.over_budget is False
+
+
+def test_launcher_local_server_evicts_stale_sibling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end wiring: launching a server evicts an older spec of that server."""
+    server_path = tmp_path / "servers" / "spack"
+    (server_path / "src").mkdir(parents=True)
+    (server_path / "pyproject.toml").write_text(
+        "[project]\nname = 'spack-mcp'\nversion = '1.0.0'\n", encoding="utf-8"
+    )
+    (server_path / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    (server_path / "src" / "server.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    cache_root = tmp_path / "cache"
+    monkeypatch.setenv("CLIO_KIT_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(clio_kit, "uv_command", lambda: "uv")
+
+    identity = clio_kit.locked_server_project_identity(server_path)
+    current_env = clio_kit._locked_server_environment_path(
+        server_path, project_sha256=identity["project_sha256"]
+    )
+    # Pre-seed a stale sibling spec for the same server.
+    stale_env, stale_project = _seed_spec(
+        cache_root, "spack", _HASHES[8], mtime=1_000.0
+    )
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        # The build (uv sync) must materialize the current environment directory.
+        if "sync" in cmd:
+            current_env.mkdir(parents=True, exist_ok=True)
+            (current_env / "bin").mkdir(parents=True, exist_ok=True)
+        return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+    monkeypatch.setattr(clio_kit.subprocess, "run", fake_run)
+
+    clio_kit._run_locked_local_server(server_path, "spack-mcp", (), os.environ.copy())
+
+    assert current_env.exists()
+    assert not stale_env.exists()
+    assert not stale_project.exists()


### PR DESCRIPTION
Closes #334.

## Problem
The launcher builds one source-and-lock addressed environment per server spec under `~/.cache/clio-kit/mcp-environments` (plus a project copy under `mcp-projects`), keyed by the project content hash, and **never reclaims the old one**. Every version/lock change mints a new directory. A storage audit on a one-month dev box found **72 full venvs for 11 servers (~9.5 GB)** beside a never-pruned private `uv-cache` (~34 GB). As the owner reframed it (iowarp/clio-agent#1001): demanding tens of GB from a user machine is a design defect, and deletion alone is palliative because the system regrows it. This fix makes the **steady state bounded** so the cache tracks the newest spec instead of accumulating history.

## What changed
New owner module `src/clio_kit/env_cache.py`; `__init__.py` only wires it into the launch path.

1. **Evict-on-upgrade.** After a server's environment for the current spec is *confirmed built* — a discrete `uv sync` gives a verifiable build signal, so a failed upgrade never destroys the previously working env — the launcher evicts that server's older spec hashes (**keep-newest-N**, default 1) across *both* the environment and project trees.
2. **Cache prune.** After a successful build + eviction, `uv cache prune` runs against the private uv cache (bounded, failure tolerated with a typed reason).
3. **Safe eviction.** Never deletes the just-built env; never deletes an env a **live server** still holds. In-use is a per-pid lockfile marker (stdlib `fcntl`/`msvcrt`, cross-platform) held across the server's lifetime; a crashed holder's marker is reclaimable.
4. **`clio-kit cache gc`** — the manual reclaim path for already-polluted boxes: applies keep-N across every server at once and **refuses (typed)** while any env is in use. Plus `clio-kit cache status` for a machine-readable footprint (supports the CI budget-assertion story).
5. **Typed structured logging** on every eviction, prune, skip, rejected config, and over-budget event — emitted to **stderr** (stdout is the child's JSON-RPC channel), never a silent deletion.

## Config (via the launcher's existing env-var surface)
`CLIO_KIT_ENV_KEEP` (default 1), `CLIO_KIT_ENV_EVICTION`, `CLIO_KIT_UV_CACHE_PRUNE`, `CLIO_KIT_CACHE_MAX_BYTES` (advisory budget). Invalid values fall back to documented defaults with a typed `cache_config_rejected` event.

## Tests (`tests/test_env_cache.py`, 16 tests)
Build N+1 evicts N keeping newest; keep-N knob; in-use env skipped (typed) + released marker unblocks; prune invoked on success / tolerated on non-zero exit / tolerated on spawn failure; gc refuses when in-use / collapses every server to keep-N / dry-run deletes nothing; config parsing + typed rejection; over-budget event; `maintain_after_build` orchestration; end-to-end launcher wiring evicts a stale sibling. Includes a sabotage twin (`test_disabled_eviction_retains_all_specs`); neutralizing eviction turns the keep-newest tests red.

## Verification
- Repo gates green on the changed surface: `ruff check scripts src tests`, `ruff format --check`, `mypy src` (clean), `pytest -q tests` (all pass except one pre-existing, environment-only failure: `test_mcp_user_contracts` live probe hitting a corrupted **global** uv cache via `uv run --isolated` — unrelated to this change, which uses the private cache).
- **Live proof on the audited box:** `cache gc` collapsed **57 stale specs across 11 servers to keep-1**, pruned the private uv-cache (402 MB → 284 MB), and a re-run is a no-op (idempotent). The real `uv sync` build command was validated against the adios server (exit 0). Every action emitted a typed `clio-kit.cache-event.v1` line.

Not merging — flagging for review; the repo's PR conventions differ from clio-agent.