### PR TITLE
fix(jarvis): reject abbreviated execution IDs

### DIFF
--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
@@ -60,6 +60,8 @@ _SPACK_ENVIRONMENT_TRANSACTION_FILENAME = ".jarvis-mcp-spack-environment.pending
 _SERVICE_RUNTIME_SCHEMA_V1 = "jarvis.service-runtime.v1"
 _SERVICE_RUNTIME_SCHEMA_V2 = "jarvis.service-runtime.v2"
 _SERVICE_RUNTIME_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_JARVIS_GENERATED_EXECUTION_ID = re.compile(r"^jarvis_[0-9a-f]{32}$")
+_JARVIS_GENERATED_EXECUTION_CANDIDATE = re.compile(r"^jarvis_[0-9a-f]*$")
 _SERVICE_RUNTIME_FIELDS_V1 = frozenset(
     {
         "schema_version",
@@ -840,7 +842,7 @@ async def get_execution(
     """Return one durable execution view with selectable owned semantics."""
     validated_pipeline = _validate_pipeline_id(pipeline_id)
     try:
-        validated_execution = _native_execution_id(execution_id)
+        validated_execution = _execution_query_id(execution_id)
     except Exception as exc:
         raise ToolError(
             _structured_runtime_error(
@@ -2571,6 +2573,24 @@ def _native_execution_id(value: str | None) -> str:
             "installed JARVIS-CD does not expose native execution handles"
         ) from exc
     return cast(str, validate_execution_id(value))
+
+
+def _execution_query_id(value: str) -> str:
+    """Validate one existing execution reference without generating a new ID."""
+    if not value:
+        raise ValueError(
+            "execution_id is required; use the exact value returned by jarvis_run"
+        )
+    if (
+        _JARVIS_GENERATED_EXECUTION_CANDIDATE.fullmatch(value) is not None
+        and _JARVIS_GENERATED_EXECUTION_ID.fullmatch(value) is None
+    ):
+        raise ValueError(
+            "JARVIS-generated execution_id must be 'jarvis_' followed by exactly "
+            "32 lowercase hexadecimal characters; use the exact value returned by "
+            "jarvis_run without abbreviation"
+        )
+    return _native_execution_id(value)
 
 
 def _require_execution_parameters(

--- a/clio-kit-mcp-servers/jarvis/tests/test_jarvis_handler.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_jarvis_handler.py
@@ -1357,6 +1357,58 @@ class TestPipelineExecutionOperations:
         load_pipeline.assert_not_called()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("execution_id", "reported_execution_id"),
+        [
+            ("", "unassigned"),
+            ("jarvis_c5d3c8ac187b0cef2956bf8256", "jarvis_c5d3c8ac187b0cef2956bf8256"),
+        ],
+    )
+    async def test_execution_query_rejects_invalid_reference_before_pipeline_load(
+        self,
+        execution_id: str,
+        reported_execution_id: str,
+    ) -> None:
+        """Invalid query references fail locally before any pipeline I/O."""
+        with (
+            patch(
+                "jarvis_mcp.capabilities.jarvis_handler._load_pipeline"
+            ) as load_pipeline,
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await get_execution("queryable", execution_id)
+
+        error = json.loads(str(exc_info.value))
+        assert error["error"]["code"] == "jarvis_execution_id_invalid"
+        assert error["error"]["execution_id"] == reported_execution_id
+        assert error["error"]["retryable"] is False
+        assert "exact value returned by jarvis_run" in error["error"]["message"]
+        load_pipeline.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "execution_id",
+        [
+            "jarvis_c5d3c8ac187b0dfe6f0cef2956bf8256",
+            "jarvis_operator-run-1",
+        ],
+    )
+    async def test_execution_query_accepts_generated_and_caller_defined_ids(
+        self,
+        execution_id: str,
+    ) -> None:
+        """Exact generated handles and caller-defined IDs remain queryable."""
+        pipeline = ModernPipeline("queryable")
+        pipeline.run(execution_id=execution_id, wait=False)
+        with patch(
+            "jarvis_mcp.capabilities.jarvis_handler._load_pipeline",
+            return_value=pipeline,
+        ):
+            result = await get_execution("queryable", execution_id)
+
+        assert result["execution_id"] == execution_id
+
+    @pytest.mark.asyncio
     async def test_run_pipeline_scheduler_mode_submits_modern_pipeline(self):
         """Scheduler mode delegates to native Pipeline.submit."""
 


### PR DESCRIPTION
## Summary

- validate `jarvis_get_execution` references without generating or silently normalizing an ID
- reject empty and abbreviated JARVIS-generated execution IDs before pipeline I/O
- preserve exact generated and caller-defined execution IDs

## Why

A truncated execution ID could reach the native lookup path and produce an opaque dependency error. The MCP now tells the agent to reuse the exact ID returned by `jarvis_run` and keeps valid operator-defined IDs compatible.

## Validation

- 77 JARVIS MCP handler tests passed from a fresh `main`-based worktree
- Ruff check passed
- Ruff format check passed
- `git diff --check` passed