### PR TITLE
fix(release): stop republishing jarvis's unchanged MCP Registry contract

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -921,7 +921,10 @@ jobs:
             print(server)
         PY
         )
-        test "${#release_servers[@]}" -gt 0
+        if [ "${#release_servers[@]}" -eq 0 ]; then
+          echo "MCP Registry: nothing to publish (no server's registry contract changed this release)"
+          exit 0
+        fi
         for server_name in "${release_servers[@]}"; do
           server_dir="clio-kit-mcp-servers/$server_name"
           test -f "$server_dir/server.json"

--- a/mcp-server-versions.toml
+++ b/mcp-server-versions.toml
@@ -1,9 +1,14 @@
 schema-version = 1
 
-# Publish the JARVIS server under a fresh immutable Registry version so its
-# package coordinate resolves the wheel containing the updated JARVIS lock.
+# Only list a server here when ITS registry contract (tool names/schemas
+# under [servers] below) actually changed this release. Republishing an
+# unchanged contract under the same version is a duplicate the Registry
+# rejects; bumping the version just to re-point the pypi wheel coordinate
+# is version churn with no semantic change. When a server's contract does
+# change, add it here WITH a real version bump under [servers] in the same
+# PR, then remove it again once published.
 [mcp-registry-release]
-publish = ["jarvis"]
+publish = []
 
 # Generated website metadata must not depend on the wall clock. Advance this
 # date intentionally whenever current contract metadata is regenerated.

--- a/scripts/generate_server_json.py
+++ b/scripts/generate_server_json.py
@@ -93,15 +93,23 @@ def read_server_versions(repo_root: Path) -> dict[str, str]:
 
 
 def read_registry_publish_servers(repo_root: Path) -> tuple[str, ...]:
-    """Read the MCP servers whose contract versions this release publishes."""
+    """Read the MCP servers whose contract versions this release publishes.
+
+    An empty list is valid and expected: it means no server's registry
+    contract (tool names/schemas under [servers]) changed this release, so
+    there is nothing to republish. A server is only listed here alongside a
+    real version bump under [servers], in the same PR that changes its
+    contract; it is removed again once published so the next release does
+    not collide with an already-published version.
+    """
     versions_path = repo_root / SERVER_VERSIONS_FILE
     with open(versions_path, "rb") as f:
         data = tomllib.load(f)
     release = data.get("mcp-registry-release")
     raw_servers = release.get("publish") if isinstance(release, dict) else None
-    if not isinstance(raw_servers, list) or not raw_servers:
+    if not isinstance(raw_servers, list):
         raise ValueError(
-            f"{versions_path} must define a nonempty mcp-registry-release.publish"
+            f"{versions_path} must define mcp-registry-release.publish as a list"
         )
     if not all(isinstance(server, str) and server for server in raw_servers):
         raise ValueError(f"{versions_path} has an invalid publish server")

--- a/tests/test_generate_server_json_contract.py
+++ b/tests/test_generate_server_json_contract.py
@@ -99,7 +99,7 @@ def test_every_committed_server_has_an_agent_runnable_package_coordinate() -> No
     assert manifests == [project / "server.json" for project in projects]
     assert list(expected_server_versions) == sorted(expected_server_versions)
     assert set(expected_server_versions) == {project.name for project in projects}
-    assert publish_servers == ("jarvis",)
+    assert publish_servers == ()
     assert marketplace["metadata"]["version"] == expected_version
     assert set(marketplace_plugins) == set(expected_server_versions)
     assert gemini_extension["version"] == expected_version


### PR DESCRIPTION
## Summary
- Closes out the v2.7.0 release: the tag's "Publish to MCP Registry" job failed with `invalid version: cannot publish duplicate version` for jarvis, because `mcp-server-versions.toml`'s `publish = ["jarvis"]` / `[servers] jarvis = "3.6.2"` were already consumed by the v2.6.6 release published hours earlier. Nothing in v2.7.0 changed jarvis's registry contract (tool names/schemas) — only its pypi_version pointer moved, which the registry manifest pipeline doesn't capture at all.
- `publish` is now `[]`. A server only belongs in that list alongside a real version bump under `[servers]`, in the same PR that changes its registry contract, and gets removed again once published — documented in a comment above the table.
- Makes an empty `publish` list a supported state instead of an error, in both `scripts/generate_server_json.py` (`read_registry_publish_servers`) and `.github/workflows/publish.yml`'s registry job (exits 0 with a clear message rather than asserting `count > 0`).
- Updates `tests/test_generate_server_json_contract.py`'s `publish_servers` assertion from `("jarvis",)` to `()`.

Rationale for removing rather than bumping (owner-reviewed, see PR): republishing an unchanged contract under a bumped version would be pure version churn with no semantic change; leaving the stale list as-is fails every future tag on a genuine duplicate. When jarvis's registry contract actually changes, it gets re-added with a real version bump in the same PR.

## Test plan
- [x] `uv run pytest -q tests`: 116 passed
- [x] `uv run pytest tests/test_generate_server_json_contract.py tests/test_release_workflow.py -v`: all pass (including the updated `publish_servers == ()` assertion)
- [x] Root ruff check/format, mypy on the touched scripts: clean
- [x] Regenerated every manifest (`scripts/generate_server_json.py`) after this change: zero diff — the publish list only feeds an "unknown project" cross-check, never gets embedded into server.json/plugin.json/.mcp.json/marketplace.json
- [x] Simulated the changed publish.yml shell block locally with today's empty `publish = []`: exits 0 with "MCP Registry: nothing to publish..." instead of failing the `-gt 0` assertion
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"`: parses clean