### PR TITLE
feat(tools): plain Title Case titles + real MCP output semantics (2.7.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/adios/src/adios_mcp/server.py
+++ b/clio-kit-mcp-servers/adios/src/adios_mcp/server.py
@@ -27,7 +27,7 @@ mcp: FastMCP = FastMCP(
 # List BP5 Files Tool
 @mcp.tool(
     name="list_bp5",
-    title="list(bp5)",
+    title="List BP5",
     description="Lists all BP5 files in a given directory. The 'directory' parameter must be an absolute path.",
     annotations={
         "readOnlyHint": True,
@@ -44,7 +44,7 @@ async def list_bp5_tool(directory: str = "data/") -> dict:
 # ─── INSPECT VARIABLES ───────────────────────────────────────────────────────
 @mcp.tool(
     name="inspect_variables",
-    title="inspect(vars)",
+    title="Inspect Variables",
     description="Inspects variables in a BP5 file, returning type, shape, and steps. Optionally filters by variable name.",
     annotations={
         "readOnlyHint": True,
@@ -63,7 +63,7 @@ async def inspect_variables_tool(
 # ─── INSPECT VARIABLES AT STEP ─────────────────────────────────────────────────
 @mcp.tool(
     name="inspect_variables_at_step",
-    title="inspect(step)",
+    title="Inspect Step Variables",
     description="Inspects a specific variable at a given step in a BP5 file. All parameters are required.",
     annotations={
         "readOnlyHint": True,
@@ -84,7 +84,7 @@ async def inspect_variables_at_step_tool(
 # ─── INSPECT ATTRIBUTES ──────────────────────────────────────────────────────
 @mcp.tool(
     name="inspect_attributes",
-    title="inspect(attrs)",
+    title="Inspect Attributes",
     description="Reads global or variable-specific attributes from a BP5 file. The 'variable_name' is optional.",
     annotations={
         "readOnlyHint": True,
@@ -103,7 +103,7 @@ async def inspect_attributes_tool(
 # ─── READ VARIABLE AT STEP ────────────────────────────────────────────────────
 @mcp.tool(
     name="read_variable_at_step",
-    title="read(step)",
+    title="Read Step Variable",
     description="Reads a named variable at a specific step from a BP5 file. All parameters are required.",
     annotations={
         "readOnlyHint": True,

--- a/clio-kit-mcp-servers/adios/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/adios/tests/test_tool_titles.py
@@ -15,3 +15,14 @@ async def test_all_tools_have_compact_titles() -> None:
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/src/arxiv_mcp/server.py
+++ b/clio-kit-mcp-servers/arxiv/src/arxiv_mcp/server.py
@@ -41,7 +41,7 @@ _READONLY_ANNOTATIONS = {
 
 @mcp.tool(
     name="search_arxiv",
-    title="search(papers)",
+    title="Search Papers",
     description="Search ArXiv for papers by category or topic.",
     annotations=_READONLY_ANNOTATIONS,
     tags={"arxiv", "search"},
@@ -57,7 +57,7 @@ async def search_arxiv_tool(query: str = "cs.AI", max_results: int = 5) -> dict:
 
 @mcp.tool(
     name="get_recent_papers",
-    title="recent(papers)",
+    title="Recent Papers",
     description="Get recent papers from a specific ArXiv category.",
     annotations=_READONLY_ANNOTATIONS,
     tags={"arxiv", "papers"},
@@ -73,7 +73,7 @@ async def get_recent_papers_tool(category: str = "cs.AI", max_results: int = 5) 
 
 @mcp.tool(
     name="search_papers_by_author",
-    title="search(author)",
+    title="Search By Author",
     description="Search ArXiv papers by author name.",
     annotations=_READONLY_ANNOTATIONS,
     tags={"arxiv", "search"},
@@ -89,7 +89,7 @@ async def search_papers_by_author_tool(author: str, max_results: int = 10) -> di
 
 @mcp.tool(
     name="search_by_title",
-    title="search(title)",
+    title="Search By Title",
     description="Search ArXiv papers by title keywords.",
     annotations=_READONLY_ANNOTATIONS,
     tags={"arxiv", "search"},
@@ -105,7 +105,7 @@ async def search_by_title_tool(title_keywords: str, max_results: int = 10) -> di
 
 @mcp.tool(
     name="search_by_abstract",
-    title="search(abstract)",
+    title="Search By Abstract",
     description="Search ArXiv papers by abstract keywords.",
     annotations=_READONLY_ANNOTATIONS,
     tags={"arxiv", "search"},
@@ -125,7 +125,7 @@ async def search_by_abstract_tool(
 
 @mcp.tool(
     name="search_by_subject",
-    title="search(subject)",
+    title="Search By Subject",
     description="Search ArXiv papers by subject classification.",
     annotations=_READONLY_ANNOTATIONS,
     tags={"arxiv", "search"},
@@ -141,7 +141,7 @@ async def search_by_subject_tool(subject: str, max_results: int = 10) -> dict:
 
 @mcp.tool(
     name="search_date_range",
-    title="search(range)",
+    title="Search By Date",
     description="Search ArXiv papers within a specific date range.",
     annotations=_READONLY_ANNOTATIONS,
     tags={"arxiv", "search"},
@@ -161,7 +161,7 @@ async def search_date_range_tool(
 
 @mcp.tool(
     name="get_paper_details",
-    title="get(paper)",
+    title="Paper Details",
     description="Get detailed information about a specific ArXiv paper by ID.",
     annotations=_READONLY_ANNOTATIONS,
     tags={"arxiv", "papers"},
@@ -177,7 +177,7 @@ async def get_paper_details_tool(arxiv_id: str) -> dict:
 
 @mcp.tool(
     name="export_to_bibtex",
-    title="export(bibtex)",
+    title="Export BibTeX",
     description="Export search results to BibTeX format for citation management.",
     annotations=_READONLY_ANNOTATIONS,
     tags={"arxiv", "export"},
@@ -193,7 +193,7 @@ async def export_to_bibtex_tool(papers_json: str) -> dict:
 
 @mcp.tool(
     name="find_similar_papers",
-    title="find(similar)",
+    title="Find Similar Papers",
     description="Find papers similar to a reference paper based on categories and keywords.",
     annotations=_READONLY_ANNOTATIONS,
     tags={"arxiv", "search"},
@@ -213,7 +213,7 @@ async def find_similar_papers_tool(
 
 @mcp.tool(
     name="download_paper_pdf",
-    title="download(pdf)",
+    title="Download PDF",
     description="Download the PDF of a paper from ArXiv.",
     annotations=_READONLY_ANNOTATIONS,
     tags={"arxiv", "download"},
@@ -231,7 +231,7 @@ async def download_paper_pdf_tool(
 
 @mcp.tool(
     name="get_pdf_url",
-    title="get(pdfurl)",
+    title="Get PDF URL",
     description="Get the direct PDF URL for a paper without downloading.",
     annotations=_READONLY_ANNOTATIONS,
     tags={"arxiv", "papers"},
@@ -247,7 +247,7 @@ async def get_pdf_url_tool(arxiv_id: str) -> dict:
 
 @mcp.tool(
     name="download_multiple_pdfs",
-    title="download(many)",
+    title="Download Multiple PDFs",
     description="Download multiple PDFs concurrently with rate limiting.",
     annotations=_READONLY_ANNOTATIONS,
     tags={"arxiv", "download"},

--- a/clio-kit-mcp-servers/arxiv/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/arxiv/tests/test_tool_titles.py
@@ -41,3 +41,14 @@ async def test_expected_tool_count_has_titles() -> None:
 
     titled = {t.name: t.title for t in tools if t.title}
     assert len(titled) == len(tools) == 13
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/src/chronomcp/server.py
+++ b/clio-kit-mcp-servers/chronolog/src/chronomcp/server.py
@@ -15,7 +15,7 @@ mcp: FastMCP = config.mcp
 
 
 @mcp.tool(
-    title="start(chronolog)",
+    title="Start Logging",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -31,7 +31,7 @@ async def start_chronolog(
 
 
 @mcp.tool(
-    title="record(interaction)",
+    title="Record Interaction",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -45,7 +45,7 @@ async def record_interaction(user_message: str, assistant_message: str) -> str:
 
 
 @mcp.tool(
-    title="stop(chronolog)",
+    title="Stop Logging",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -59,7 +59,7 @@ async def stop_chronolog() -> str:
 
 
 @mcp.tool(
-    title="retrieve(logs)",
+    title="Retrieve Logs",
     annotations={
         "readOnlyHint": True,
         "destructiveHint": False,

--- a/clio-kit-mcp-servers/chronolog/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/chronolog/tests/test_tool_titles.py
@@ -26,3 +26,16 @@ async def test_all_tools_have_compact_titles() -> None:
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    from fastmcp import Client
+
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/src/compression_mcp/server.py
+++ b/clio-kit-mcp-servers/compression/src/compression_mcp/server.py
@@ -26,7 +26,7 @@ mcp: FastMCP = FastMCP(
 
 
 @mcp.tool(
-    title="compress(file)",
+    title="Compress",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -45,7 +45,7 @@ async def compress_file_tool(
 
 
 @mcp.tool(
-    title="decompress(file)",
+    title="Decompress",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,

--- a/clio-kit-mcp-servers/compression/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/compression/tests/test_tool_titles.py
@@ -15,3 +15,14 @@ async def test_all_tools_have_compact_titles() -> None:
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/src/darshan_mcp/server.py
+++ b/clio-kit-mcp-servers/darshan/src/darshan_mcp/server.py
@@ -41,7 +41,7 @@ _READ_ONLY_ANNOTATIONS = {
 
 @mcp.tool(
     name="load_darshan_log",
-    title="load(log)",
+    title="Load Log",
     description="Load and parse a Darshan log file to extract I/O performance metrics and metadata.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"darshan", "io-analysis"},
@@ -63,7 +63,7 @@ async def load_darshan_log_tool(log_file_path: str) -> dict:
 
 @mcp.tool(
     name="get_job_summary",
-    title="get(job summary)",
+    title="Job Summary",
     description="Get job-level summary from a Darshan log including runtime, process count, and I/O volume.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"darshan", "io-analysis"},
@@ -85,7 +85,7 @@ async def get_job_summary_tool(log_file_path: str) -> dict:
 
 @mcp.tool(
     name="analyze_file_access_patterns",
-    title="analyze(access)",
+    title="Analyze File Access",
     description="Analyze file access patterns including read/write types and sequential vs random access.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"darshan", "io-analysis"},
@@ -112,7 +112,7 @@ async def analyze_file_access_patterns_tool(
 
 @mcp.tool(
     name="get_io_performance_metrics",
-    title="get(io metrics)",
+    title="IO Performance",
     description="Extract I/O performance metrics including bandwidth, IOPS, and request sizes.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"darshan", "performance"},
@@ -134,7 +134,7 @@ async def get_io_performance_metrics_tool(log_file_path: str) -> dict:
 
 @mcp.tool(
     name="analyze_posix_operations",
-    title="analyze(posix)",
+    title="Analyze POSIX Ops",
     description="Analyze POSIX I/O operations including read/write system calls and their frequency.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"darshan", "io-analysis"},
@@ -156,7 +156,7 @@ async def analyze_posix_operations_tool(log_file_path: str) -> dict:
 
 @mcp.tool(
     name="analyze_mpiio_operations",
-    title="analyze(mpiio)",
+    title="Analyze MPI-IO Ops",
     description="Analyze MPI-IO operations including collective vs independent operations.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"darshan", "io-analysis"},
@@ -178,7 +178,7 @@ async def analyze_mpiio_operations_tool(log_file_path: str) -> dict:
 
 @mcp.tool(
     name="identify_io_bottlenecks",
-    title="find(bottlenecks)",
+    title="Find Bottlenecks",
     description="Identify I/O performance bottlenecks by analyzing access patterns and operations.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"darshan", "performance"},
@@ -200,7 +200,7 @@ async def identify_io_bottlenecks_tool(log_file_path: str) -> dict:
 
 @mcp.tool(
     name="get_timeline_analysis",
-    title="get(timeline)",
+    title="Timeline Analysis",
     description="Generate timeline analysis showing I/O activity over time and temporal patterns.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"darshan", "performance"},
@@ -225,7 +225,7 @@ async def get_timeline_analysis_tool(
 
 @mcp.tool(
     name="compare_darshan_logs",
-    title="compare(logs)",
+    title="Compare Logs",
     description="Compare two Darshan log files to identify performance differences between runs.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"darshan", "performance"},
@@ -255,7 +255,7 @@ async def compare_darshan_logs_tool(
 
 @mcp.tool(
     name="generate_io_summary_report",
-    title="generate(report)",
+    title="Summary Report",
     description="Generate a comprehensive I/O summary report with findings and recommendations.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"darshan", "performance"},

--- a/clio-kit-mcp-servers/darshan/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/darshan/tests/test_tool_titles.py
@@ -41,3 +41,14 @@ async def test_titles_are_distinct_within_server() -> None:
     assert len(titles) == len(set(titles)), (
         "Duplicate titles found within darshan server"
     )
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/src/geo_mcp/server.py
+++ b/clio-kit-mcp-servers/geo/src/geo_mcp/server.py
@@ -7,13 +7,14 @@ visualized as a layered map with an optional web-tile basemap.
 """
 
 import logging
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal, cast
 
 from dotenv import load_dotenv
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.prompts import Message
 from pydantic import Field
+from typing_extensions import NotRequired, TypedDict
 
 from .implementation import (
     ArcGISQueryError,
@@ -27,6 +28,159 @@ from .implementation import (
     query_arcgis_features,
     render_map,
 )
+
+# --- Structured result shapes (drive real MCP outputSchema declarations) ----
+
+
+class MapLayerSummary(TypedDict):
+    """Per-layer feature/geometry summary within a rendered map result.
+
+    ``skipped`` is present only when the layer had no usable geometries;
+    ``geometry`` is present only when it did — the two are mutually
+    exclusive, but both are optional so one TypedDict covers both outcomes.
+    """
+
+    name: str
+    features: int
+    geometry: NotRequired[list[str]]
+    skipped: NotRequired[Literal["no features"]]
+
+
+class MapBounds(TypedDict):
+    """WGS84 bounding box merged across every rendered layer."""
+
+    min_lon: float
+    min_lat: float
+    max_lon: float
+    max_lat: float
+
+
+class RenderFeatureMapResult(TypedDict):
+    """Structured result for a successful render_feature_map call."""
+
+    status: Literal["success"]
+    output_path: str
+    size_bytes: int
+    bounds: MapBounds
+    basemap: bool
+    layers: list[MapLayerSummary]
+
+
+class MatchedPoint(TypedDict):
+    """One point that fell within the (optionally buffered) query polygons."""
+
+    index: int
+    lon: float
+    lat: float
+    properties: dict[str, Any]
+
+
+class PointsInPolygonsResult(TypedDict):
+    """Structured result for a successful points_in_polygons call.
+
+    Every return path in the implementation (no input points, no input
+    polygons, or a normal overlap) produces this exact same shape — only the
+    counts and ``matched`` contents vary — so one TypedDict covers all of
+    them; no discriminated union is needed here.
+    """
+
+    status: Literal["success"]
+    points_total: int
+    polygons_total: int
+    matched_count: int
+    matched: list[MatchedPoint]
+
+
+class BoundingBoxResult(TypedDict):
+    """Structured result for a bounding_box call.
+
+    ``status`` is ``"empty"`` when the input GeoJSON had no usable
+    geometries — ``bbox`` is then ``None`` and ``feature_count`` is 0.
+    Otherwise ``status`` is ``"success"`` and ``bbox`` carries
+    ``[min_lon, min_lat, max_lon, max_lat]``.
+
+    Modeled as one TypedDict with a two-value ``status`` Literal rather than
+    a ``Field(discriminator=...)`` union: a discriminated union's JSON Schema
+    root is a bare ``oneOf``/``discriminator`` object with no ``type: object``
+    key, which trips FastMCP's non-object-output-schema auto-wrap
+    (``x-fastmcp-wrap-result``) and would silently change this tool's
+    structured_content from a bare dict to ``{"result": {...}}``.
+    """
+
+    status: Literal["success", "empty"]
+    feature_count: int
+    bbox: list[float] | None
+
+
+class ArcGISFeature(TypedDict):
+    """One GeoJSON-like feature returned by an ArcGIS FeatureServer query.
+
+    ``geometry`` is a compact summary, not raw ArcGIS geometry: a point
+    ``{x, y}``, a sampled ring ``{bbox, point_count_sampled}``, or a
+    last-resort ``{geometry_keys}`` fallback — genuinely freeform.
+    """
+
+    type: Literal["Feature"]
+    properties: dict[str, Any]
+    geometry: dict[str, Any]
+
+
+class QueryArcGISFeaturesResult(TypedDict):
+    """Structured result for a successful query_arcgis_features call."""
+
+    ok: Literal[True]
+    status: Literal["success"]
+    source_url: str
+    query_url: str
+    output_path: str
+    output_size_bytes: int
+    feature_count: int
+    geometry_type: str | None
+    fields: list[str]
+    features: list[ArcGISFeature]
+    features_truncated: bool
+
+
+class GeocodeMatch(TypedDict):
+    """One geocoded location match from OpenStreetMap Nominatim."""
+
+    display_name: str | None
+    lat: float
+    lon: float
+    bbox: list[float] | None
+    type: str | None
+    importance: float | None
+    provenance: Literal["osm_nominatim"]
+
+
+class DistanceFilterCenter(TypedDict):
+    """Center coordinate used for a filter_points_by_radius query."""
+
+    lat: float
+    lon: float
+
+
+class FilterPointsByRadiusResult(TypedDict):
+    """Structured result for a successful filter_points_by_radius call.
+
+    ``points`` entries carry the source row's own (freeform) columns plus an
+    always-present ``distance_km`` and, when ``id_column`` was given, an
+    ``id`` field — the base columns are genuinely open-ended, so each point
+    stays ``dict[str, Any]``.
+    """
+
+    ok: Literal[True]
+    count: int
+    within_radius_count: int
+    total_points: int
+    skipped_invalid: int
+    source_format: Literal["csv", "geojson"]
+    lat_column: str
+    lon_column: str
+    center: DistanceFilterCenter
+    radius_km: float
+    points: list[dict[str, Any]]
+
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -49,7 +203,7 @@ mcp: FastMCP = FastMCP(
 
 @mcp.tool(
     name="render_feature_map",
-    title="map(render)",
+    title="Render Map",
     description=(
         "Render one or more GeoJSON layers (polygons/lines/points) onto a single "
         "map PNG with an optional basemap. Each layer accepts a style with fixed "
@@ -80,10 +234,13 @@ async def render_feature_map_tool(
         list[float] | None,
         Field(description="Optional view window [min_lon, min_lat, max_lon, max_lat]."),
     ] = None,
-) -> dict[str, Any]:
+) -> RenderFeatureMapResult:
     """Render GeoJSON layers to a map PNG. See tool description for the layer schema."""
     try:
-        return render_map(layers, output_path, title=title, basemap=basemap, bbox=bbox)
+        return cast(
+            RenderFeatureMapResult,
+            render_map(layers, output_path, title=title, basemap=basemap, bbox=bbox),
+        )
     except MapRenderError as exc:
         raise ToolError(str(exc)) from exc
     except Exception as exc:  # noqa: BLE001 - surface rendering failures as tool errors
@@ -93,7 +250,7 @@ async def render_feature_map_tool(
 
 @mcp.tool(
     name="points_in_polygons",
-    title="join(points)",
+    title="Points In Polygons",
     description=(
         "Spatial overlap: return which GeoJSON points fall within (optionally "
         "buffered) GeoJSON polygons — e.g. which AirNow monitors lie inside the "
@@ -115,14 +272,17 @@ async def points_in_polygons_tool(
     point_label_fields: Annotated[
         list[str] | None, Field(description="Property names to surface per matched point.")
     ] = None,
-) -> dict[str, Any]:
+) -> PointsInPolygonsResult:
     """Return the points that fall within (optionally buffered) polygons."""
     try:
-        return points_in_polygons(
-            points_geojson,
-            polygons_geojson,
-            buffer_km=buffer_km,
-            point_label_fields=point_label_fields,
+        return cast(
+            PointsInPolygonsResult,
+            points_in_polygons(
+                points_geojson,
+                polygons_geojson,
+                buffer_km=buffer_km,
+                point_label_fields=point_label_fields,
+            ),
         )
     except Exception as exc:  # noqa: BLE001 - surface as tool error
         logger.exception("points_in_polygons failed")
@@ -131,7 +291,7 @@ async def points_in_polygons_tool(
 
 @mcp.tool(
     name="bounding_box",
-    title="compute(bbox)",
+    title="Bounding Box",
     description=(
         "Compute the bounding box [min_lon, min_lat, max_lon, max_lat] of GeoJSON "
         "features (inline or file path), optionally padded by buffer_km. A "
@@ -145,10 +305,10 @@ async def bounding_box_tool(
         Any, Field(description="GeoJSON features (FeatureCollection/Feature/list/JSON/path).")
     ],
     pad_km: Annotated[float, Field(description="Optional padding in km added on each side.")] = 0.0,
-) -> dict[str, Any]:
+) -> BoundingBoxResult:
     """Return the (optionally padded) bounding box of GeoJSON features."""
     try:
-        return bounding_box(geojson, pad_km=pad_km)
+        return cast(BoundingBoxResult, bounding_box(geojson, pad_km=pad_km))
     except Exception as exc:  # noqa: BLE001
         logger.exception("bounding_box failed")
         raise ToolError(f"Bounding box failed: {exc}") from exc
@@ -156,7 +316,7 @@ async def bounding_box_tool(
 
 @mcp.tool(
     name="query_arcgis_features",
-    title="query(arcgis)",
+    title="Query ArcGIS",
     description=(
         "Query an ArcGIS FeatureServer layer (with optional lon/lat bbox and where "
         "clause) and write the returned features to a local GeoJSON file. The saved "
@@ -195,7 +355,7 @@ async def query_arcgis_features_tool(
         str | None,
         Field(description="Output GeoJSON path; auto-named under the artifacts root if omitted."),
     ] = None,
-) -> dict[str, Any]:
+) -> QueryArcGISFeaturesResult:
     """Query an ArcGIS FeatureServer layer and persist features as GeoJSON.
 
     Returns ``{ok, output_path, feature_count, geometry_type, fields, features, ...}``
@@ -203,17 +363,20 @@ async def query_arcgis_features_tool(
     ``output_path``.
     """
     try:
-        return await query_arcgis_features(
-            feature_service_url,
-            layer_id=layer_id,
-            where=where,
-            out_fields=out_fields,
-            max_features=max_features,
-            min_lon=min_lon,
-            min_lat=min_lat,
-            max_lon=max_lon,
-            max_lat=max_lat,
-            output_path=output_path,
+        return cast(
+            QueryArcGISFeaturesResult,
+            await query_arcgis_features(
+                feature_service_url,
+                layer_id=layer_id,
+                where=where,
+                out_fields=out_fields,
+                max_features=max_features,
+                min_lon=min_lon,
+                min_lat=min_lat,
+                max_lon=max_lon,
+                max_lat=max_lat,
+                output_path=output_path,
+            ),
         )
     except ArcGISQueryError as exc:
         raise ToolError(str(exc)) from exc
@@ -224,7 +387,7 @@ async def query_arcgis_features_tool(
 
 @mcp.tool(
     name="geocode",
-    title="geocode(place)",
+    title="Geocode",
     description=(
         "Look up a free-text place name or location and return real coordinates "
         "from OpenStreetMap Nominatim (a lookup, not a model guess). Each match "
@@ -252,7 +415,7 @@ async def geocode_tool(
             )
         ),
     ] = None,
-) -> list[dict[str, Any]]:
+) -> list[GeocodeMatch]:
     """Geocode a place name into coordinates via OpenStreetMap Nominatim.
 
     Returns a list of matches, each with ``display_name``, ``lat``, ``lon``,
@@ -260,7 +423,9 @@ async def geocode_tool(
     and ``provenance`` (the data source, e.g. ``"osm_nominatim"``).
     """
     try:
-        return await geocode(query, limit=limit, countrycodes=countrycodes)
+        return cast(
+            list[GeocodeMatch], await geocode(query, limit=limit, countrycodes=countrycodes)
+        )
     except GeocodeError as exc:
         raise ToolError(str(exc)) from exc
     except Exception as exc:  # noqa: BLE001 - surface lookup failures as tool errors
@@ -270,7 +435,7 @@ async def geocode_tool(
 
 @mcp.tool(
     name="filter_points_by_radius",
-    title="filter(radius)",
+    title="Filter By Radius",
     description=(
         "Filter/rank any table of points by great-circle distance to a center. "
         "Reads a CSV (or GeoJSON points) of locations, computes the haversine "
@@ -315,7 +480,7 @@ async def filter_points_by_radius_tool(
         int | None,
         Field(description="Optional cap on the number of returned points (after sorting)."),
     ] = None,
-) -> dict[str, Any]:
+) -> FilterPointsByRadiusResult:
     """Return the points within radius_km of the center, sorted by distance.
 
     Returns ``{ok, count, within_radius_count, points:[{..., distance_km}],
@@ -323,15 +488,18 @@ async def filter_points_by_radius_tool(
     station/catalog semantics.
     """
     try:
-        return filter_points_by_radius(
-            data_path,
-            center_lat,
-            center_lon,
-            radius_km,
-            lat_column=lat_column,
-            lon_column=lon_column,
-            id_column=id_column,
-            limit=limit,
+        return cast(
+            FilterPointsByRadiusResult,
+            filter_points_by_radius(
+                data_path,
+                center_lat,
+                center_lon,
+                radius_km,
+                lat_column=lat_column,
+                lon_column=lon_column,
+                id_column=id_column,
+                limit=limit,
+            ),
         )
     except ProximityError as exc:
         raise ToolError(str(exc)) from exc

--- a/clio-kit-mcp-servers/geo/tests/test_arcgis.py
+++ b/clio-kit-mcp-servers/geo/tests/test_arcgis.py
@@ -321,8 +321,8 @@ async def test_tool_runs_in_memory(fake_http, tmp_path) -> None:
                 "output_path": str(out),
             },
         )
-    assert result.data["ok"] is True
-    assert result.data["feature_count"] == 2
+    assert result.structured_content["ok"] is True
+    assert result.structured_content["feature_count"] == 2
     assert out.is_file()
 
 

--- a/clio-kit-mcp-servers/geo/tests/test_capabilities.py
+++ b/clio-kit-mcp-servers/geo/tests/test_capabilities.py
@@ -29,4 +29,4 @@ async def test_render_tool_runs_in_memory(tmp_path) -> None:
             },
         )
     assert out.is_file() and out.stat().st_size > 0
-    assert result.data["status"] == "success"
+    assert result.structured_content["status"] == "success"

--- a/clio-kit-mcp-servers/geo/tests/test_geocode.py
+++ b/clio-kit-mcp-servers/geo/tests/test_geocode.py
@@ -239,7 +239,9 @@ async def test_tool_registered() -> None:
 async def test_tool_runs_in_memory(fake_http) -> None:
     async with Client(mcp) as client:
         result = await client.call_tool("geocode", {"query": "Boulder, CO", "limit": 1})
-    matches = result.data
+    # geocode returns a bare list, which FastMCP wraps as {"result": [...]}
+    # in structured_content since MCP output schemas must be object-shaped.
+    matches = result.structured_content["result"]
     assert isinstance(matches, list)
     assert matches[0]["provenance"] == "osm_nominatim"
     assert matches[0]["bbox"] == [

--- a/clio-kit-mcp-servers/geo/tests/test_output_schemas.py
+++ b/clio-kit-mcp-servers/geo/tests/test_output_schemas.py
@@ -1,0 +1,197 @@
+"""Verify geo tools declare real MCP output semantics (2026-07-28 protocol).
+
+Every geo tool's registration must advertise a real, field-level
+``outputSchema`` — not the generic ``{"type": "object",
+"additionalProperties": true}`` a bare ``-> dict`` / ``-> dict[str, Any]``
+return annotation would produce. These tests drive the server through an
+in-memory ``fastmcp.Client``, so they exercise exactly what a real MCP client
+sees on the wire, and spot-check that a couple of tools' actual
+structured_content matches the advertised schema's field names.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+
+from geo_mcp.server import mcp
+
+ALL_TOOL_NAMES = {
+    "render_feature_map",
+    "points_in_polygons",
+    "bounding_box",
+    "query_arcgis_features",
+    "geocode",
+    "filter_points_by_radius",
+}
+
+POLY = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {"smoke": "3-25"},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[-118.5, 34.0], [-118.0, 34.0], [-118.0, 34.5], [-118.5, 34.5], [-118.5, 34.0]]
+                ],
+            },
+        }
+    ],
+}
+
+
+def _pt(lon: float, lat: float, **props: object) -> dict:
+    return {
+        "type": "Feature",
+        "properties": props,
+        "geometry": {"type": "Point", "coordinates": [lon, lat]},
+    }
+
+
+@pytest.mark.asyncio
+async def test_tools_list_advertises_real_output_schemas() -> None:
+    """tools/list must show a field-level outputSchema for every geo tool."""
+    async with Client(mcp) as client:
+        tools = {tool.name: tool for tool in await client.list_tools()}
+
+    missing = ALL_TOOL_NAMES - set(tools)
+    assert not missing, f"tools missing from tools/list: {missing}"
+
+    for name in ALL_TOOL_NAMES:
+        schema = tools[name].output_schema
+        assert schema is not None, f"{name} has no outputSchema"
+        assert schema.get("type") == "object", f"{name} outputSchema is not an object"
+        properties = schema.get("properties")
+        assert properties, f"{name} outputSchema has no real field properties: {schema}"
+
+
+@pytest.mark.asyncio
+async def test_bounding_box_schema_covers_both_status_values() -> None:
+    """bounding_box unifies the empty/success outcomes into one schema whose
+    ``status`` property enumerates both values (no info lost by not using a
+    discriminated union)."""
+    async with Client(mcp) as client:
+        tools = {tool.name: tool for tool in await client.list_tools()}
+
+    status_schema = tools["bounding_box"].output_schema["properties"]["status"]
+    assert set(status_schema.get("enum", [])) == {"success", "empty"}
+
+
+@pytest.mark.asyncio
+async def test_bounding_box_empty_result_matches_schema_fields() -> None:
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "bounding_box", {"geojson": {"type": "FeatureCollection", "features": []}}
+        )
+    structured = result.structured_content
+    assert structured == {"status": "empty", "bbox": None, "feature_count": 0}
+
+
+@pytest.mark.asyncio
+async def test_bounding_box_success_result_matches_schema_fields() -> None:
+    async with Client(mcp) as client:
+        result = await client.call_tool("bounding_box", {"geojson": POLY})
+    structured = result.structured_content
+    assert structured is not None
+    assert structured["status"] == "success"
+    assert structured["feature_count"] == 1
+    assert structured["bbox"] == [-118.5, 34.0, -118.0, 34.5]
+
+
+@pytest.mark.asyncio
+async def test_points_in_polygons_result_matches_schema_fields() -> None:
+    points = {
+        "type": "FeatureCollection",
+        "features": [
+            _pt(-118.2, 34.2, AQI=168, name="in"),
+            _pt(-117.0, 33.0, AQI=20, name="out"),
+        ],
+    }
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "points_in_polygons",
+            {
+                "points_geojson": points,
+                "polygons_geojson": POLY,
+                "point_label_fields": ["AQI", "name"],
+            },
+        )
+    structured = result.structured_content
+    assert structured is not None
+    assert structured["status"] == "success"
+    assert structured["points_total"] == 2
+    assert structured["matched_count"] == 1
+    assert structured["matched"][0]["properties"] == {"AQI": 168, "name": "in"}
+
+
+@pytest.mark.asyncio
+async def test_filter_points_by_radius_result_matches_schema_fields(tmp_path: Path) -> None:
+    csv_path = tmp_path / "points.csv"
+    csv_path.write_text(
+        "name,latitude,longitude\nnear,34.05,-118.25\nfar,0.0,0.0\n", encoding="utf-8"
+    )
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "filter_points_by_radius",
+            {
+                "data_path": str(csv_path),
+                "center_lat": 34.05,
+                "center_lon": -118.25,
+                "radius_km": 10,
+            },
+        )
+    structured = result.structured_content
+    assert structured is not None
+    assert structured["ok"] is True
+    assert structured["count"] == 1
+    assert structured["source_format"] == "csv"
+    assert structured["center"] == {"lat": 34.05, "lon": -118.25}
+    assert structured["points"][0]["name"] == "near"
+    assert "distance_km" in structured["points"][0]
+
+
+@pytest.mark.asyncio
+async def test_render_feature_map_result_matches_schema_fields(tmp_path: Path) -> None:
+    out = tmp_path / "map.png"
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "render_feature_map",
+            {
+                "layers": [{"name": "region", "geojson": POLY, "style": {"facecolor": "red"}}],
+                "output_path": str(out),
+                "basemap": False,
+            },
+        )
+    structured = result.structured_content
+    assert structured is not None
+    assert structured["status"] == "success"
+    assert structured["basemap"] is False
+    assert structured["layers"][0] == {"name": "region", "features": 1, "geometry": ["Polygon"]}
+    assert out.is_file()
+
+
+@pytest.mark.asyncio
+async def test_render_feature_map_skipped_layer_matches_schema_fields(tmp_path: Path) -> None:
+    """A layer with no usable geometries carries ``skipped`` instead of
+    ``geometry`` — both are modeled as optional fields on one TypedDict."""
+    out = tmp_path / "map.png"
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "render_feature_map",
+            {
+                "layers": [
+                    {"name": "empty", "geojson": {"type": "FeatureCollection", "features": []}},
+                    {"name": "region", "geojson": POLY, "style": {"facecolor": "red"}},
+                ],
+                "output_path": str(out),
+                "basemap": False,
+            },
+        )
+    structured = result.structured_content
+    assert structured is not None
+    assert structured["layers"][0] == {"name": "empty", "features": 0, "skipped": "no features"}
+    assert structured["layers"][1] == {"name": "region", "features": 1, "geometry": ["Polygon"]}

--- a/clio-kit-mcp-servers/geo/tests/test_proximity.py
+++ b/clio-kit-mcp-servers/geo/tests/test_proximity.py
@@ -261,8 +261,8 @@ async def test_tool_runs_in_memory(tmp_path):
                 "radius_km": 25.0,
             },
         )
-    assert result.data["ok"] is True
-    assert [p["name"] for p in result.data["points"]] == ["near", "mid", "far_in"]
+    assert result.structured_content["ok"] is True
+    assert [p["name"] for p in result.structured_content["points"]] == ["near", "mid", "far_in"]
 
 
 @pytest.mark.asyncio

--- a/clio-kit-mcp-servers/geo/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/geo/tests/test_tool_titles.py
@@ -1,8 +1,10 @@
 """Every tool the geo MCP server registers must carry a compact display title.
 
 The consuming UI reads `Tool.title` (falling back to `annotations.title`, then
-`name`) to render a small-title register — e.g. `geocode(place)`. This asserts
-every tool advertises one, and that it fits the compact register's length budget.
+`name`) to render a compact register of plain Title Case names — e.g. `Geocode`.
+Parens are injected by the UI around the call's arguments, not part of the
+title. This asserts every tool advertises one, and that it fits the compact
+register's length budget.
 """
 
 import pytest
@@ -29,3 +31,14 @@ async def test_titles_fit_the_compact_register() -> None:
 
     too_long = {t.name: t.title for t in tools if t.title and len(t.title) > MAX_TITLE_LENGTH}
     assert not too_long, f"titles exceed {MAX_TITLE_LENGTH} chars: {too_long}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/src/geojson_mcp/server.py
+++ b/clio-kit-mcp-servers/geojson/src/geojson_mcp/server.py
@@ -58,7 +58,7 @@ _SourceField = Annotated[
 
 @mcp.tool(
     name="inspect_geojson",
-    title="inspect(geojson)",
+    title="Inspect",
     description=(
         "Inspect a GeoJSON document and report its geometry types and counts, "
         "feature count, property keys (schema), bounding box "
@@ -91,7 +91,7 @@ async def inspect_geojson_tool(
 
 @mcp.tool(
     name="validate_geojson",
-    title="validate(geojson)",
+    title="Validate",
     description=(
         "Validate the structural well-formedness of a GeoJSON document: that "
         "the top-level type is recognized and every geometry's type and "
@@ -114,7 +114,7 @@ async def validate_geojson_tool(source: _SourceField) -> dict[str, Any]:
 
 @mcp.tool(
     name="summarize_geojson",
-    title="summarize(geojson)",
+    title="Summarize",
     description=(
         "Produce a compact human-readable summary of a GeoJSON document: counts "
         "per geometry type, bounding box, property keys, and a few sample "
@@ -142,7 +142,7 @@ async def summarize_geojson_tool(
 
 @mcp.tool(
     name="feature_bbox",
-    title="compute(bbox)",
+    title="Bounding Box",
     description=(
         "Compute the overall bounding box [min_lon, min_lat, max_lon, max_lat] "
         "of all features in a GeoJSON document. Accepts a file path or inline "

--- a/clio-kit-mcp-servers/geojson/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/geojson/tests/test_tool_titles.py
@@ -28,3 +28,14 @@ async def test_every_tool_has_a_short_title() -> None:
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/src/hdf5_mcp/server.py
+++ b/clio-kit-mcp-servers/hdf5/src/hdf5_mcp/server.py
@@ -231,7 +231,7 @@ def with_error_handling(func):
 
 
 @mcp.tool(
-    title="open(file)",
+    title="Open File",
     tags={"file", "core"},
     annotations={
         "title": "Open HDF5 File",
@@ -265,7 +265,7 @@ async def open_file(path: str, mode: str = "r") -> str:
 
 
 @mcp.tool(
-    title="close(file)",
+    title="Close File",
     tags={"file", "core"},
     annotations={
         "title": "Close HDF5 File",
@@ -294,7 +294,7 @@ async def close_file() -> str:
 
 
 @mcp.tool(
-    title="get(filename)",
+    title="Get Filename",
     tags={"file", "info"},
     annotations={
         "title": "Get Current Filename",
@@ -318,7 +318,7 @@ async def get_filename() -> str:
 
 
 @mcp.tool(
-    title="get(mode)",
+    title="Get Mode",
     tags={"file", "info"},
     annotations={
         "title": "Get File Access Mode",
@@ -342,7 +342,7 @@ async def get_mode() -> str:
 
 
 @mcp.tool(
-    title="get(object)",
+    title="Get Object",
     tags={"dataset", "navigation"},
     annotations={
         "title": "Get Object by Path",
@@ -380,7 +380,7 @@ async def get_by_path(path: str) -> str:
 
 
 @mcp.tool(
-    title="list(keys)",
+    title="List Keys",
     tags={"dataset", "navigation"},
     annotations={
         "title": "List Keys in Group",
@@ -416,7 +416,7 @@ async def list_keys(path: str = "/") -> str:
 
 
 @mcp.tool(
-    title="visit(nodes)",
+    title="Visit Nodes",
     tags={"dataset", "navigation"},
     annotations={
         "title": "Visit All Nodes Recursively",
@@ -456,7 +456,7 @@ async def visit(callback_fn: str = "collect_paths") -> str:
 
 
 @mcp.tool(
-    title="read(full)",
+    title="Read Dataset",
     tags={"dataset", "read"},
     annotations={
         "title": "Read Full Dataset",
@@ -504,7 +504,7 @@ async def read_full_dataset(path: str) -> str:
 
 
 @mcp.tool(
-    title="read(slice)",
+    title="Read Slice",
     tags={"dataset", "read"},
     annotations={
         "title": "Read Partial Dataset",
@@ -565,7 +565,7 @@ async def read_partial_dataset(
 
 
 @mcp.tool(
-    title="get(shape)",
+    title="Get Shape",
     tags={"dataset", "metadata"},
     annotations={
         "title": "Get Dataset Shape",
@@ -601,7 +601,7 @@ async def get_shape(path: str) -> str:
 
 
 @mcp.tool(
-    title="get(dtype)",
+    title="Get Dtype",
     tags={"dataset", "metadata"},
     annotations={
         "title": "Get Dataset Data Type",
@@ -637,7 +637,7 @@ async def get_dtype(path: str) -> str:
 
 
 @mcp.tool(
-    title="get(size)",
+    title="Get Size",
     tags={"dataset", "metadata"},
     annotations={
         "title": "Get Dataset Size",
@@ -673,7 +673,7 @@ async def get_size(path: str) -> str:
 
 
 @mcp.tool(
-    title="get(chunks)",
+    title="Get Chunks",
     tags={"dataset", "metadata", "performance"},
     annotations={
         "title": "Get Dataset Chunk Info",
@@ -723,7 +723,7 @@ async def get_chunks(path: str) -> str:
 
 
 @mcp.tool(
-    title="read(attr)",
+    title="Read Attribute",
     tags={"attribute", "metadata"},
     annotations={
         "title": "Read Attribute",
@@ -763,7 +763,7 @@ async def read_attribute(path: str, name: str) -> str:
 
 
 @mcp.tool(
-    title="list(attrs)",
+    title="List Attributes",
     tags={"attribute", "metadata"},
     annotations={
         "title": "List All Attributes",
@@ -813,7 +813,7 @@ async def list_attributes(path: str) -> str:
 
 
 @mcp.tool(
-    title="scan(parallel)",
+    title="Parallel Scan",
     tags={"performance", "parallel", "scan"},
     annotations={
         "title": "Parallel Scan Multiple Files",
@@ -898,7 +898,7 @@ async def hdf5_parallel_scan(
 
 
 @mcp.tool(
-    title="read(batch)",
+    title="Batch Read",
     tags={"performance", "parallel", "read"},
     annotations={
         "title": "Batch Read Multiple Datasets",
@@ -986,7 +986,7 @@ async def hdf5_batch_read(
 
 
 @mcp.tool(
-    title="stream(data)",
+    title="Stream Data",
     tags={"performance", "streaming"},
     annotations={
         "title": "Stream Large Dataset",
@@ -1093,7 +1093,7 @@ async def hdf5_stream_data(
 
 
 @mcp.tool(
-    title="stats(aggregate)",
+    title="Aggregate Stats",
     tags={"performance", "parallel", "analysis"},
     annotations={
         "title": "Aggregate Statistics Across Datasets",
@@ -1218,7 +1218,7 @@ async def hdf5_aggregate_stats(
 
 
 @mcp.tool(
-    title="analyze(structure)",
+    title="Analyze Structure",
     tags={"discovery", "ai-powered", "analysis"},
     annotations={
         "title": "Analyze Dataset Structure",
@@ -1343,7 +1343,7 @@ async def analyze_dataset_structure(
 
 
 @mcp.tool(
-    title="find(similar)",
+    title="Find Similar Datasets",
     tags={"discovery", "ai-powered", "similarity"},
     annotations={
         "title": "Find Similar Datasets",
@@ -1454,7 +1454,7 @@ async def find_similar_datasets(
 
 
 @mcp.tool(
-    title="suggest(next)",
+    title="Suggest Next Step",
     tags={"discovery", "ai-powered", "recommendation"},
     annotations={
         "title": "Suggest Next Exploration",
@@ -1576,7 +1576,7 @@ async def suggest_next_exploration(
 
 
 @mcp.tool(
-    title="find(bottlenecks)",
+    title="Find Bottlenecks",
     tags={"discovery", "ai-powered", "performance"},
     annotations={
         "title": "Identify I/O Bottlenecks",
@@ -1682,7 +1682,7 @@ async def identify_io_bottlenecks(
 
 
 @mcp.tool(
-    title="optimize(access)",
+    title="Optimize Access",
     tags={"discovery", "performance", "optimization"},
     annotations={
         "title": "Optimize Access Pattern",
@@ -1773,7 +1773,7 @@ async def optimize_access_pattern(
 
 
 @mcp.tool(
-    title="refresh(files)",
+    title="Refresh Files",
     tags={"admin", "discovery"},
     annotations={
         "title": "Refresh HDF5 Resources",
@@ -1813,7 +1813,7 @@ async def refresh_hdf5_resources(ctx: Optional[Context] = None) -> str:
 
 
 @mcp.tool(
-    title="list(files)",
+    title="List Files",
     tags={"discovery", "helper"},
     annotations={
         "title": "List Available HDF5 Files",
@@ -1847,7 +1847,7 @@ async def list_available_hdf5_files() -> str:
 
 
 @mcp.tool(
-    title="export(dataset)",
+    title="Export Dataset",
     tags={"dataset", "export", "interactive"},
     annotations={
         "title": "Export Dataset",

--- a/clio-kit-mcp-servers/hdf5/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/hdf5/tests/test_tool_titles.py
@@ -22,3 +22,14 @@ async def test_all_tools_have_compact_titles() -> None:
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
@@ -1263,7 +1263,7 @@ def create_pipeline_workflow(name: str) -> list[Message]:
 
 @mcp.tool(
     name="update_pipeline",
-    title="reapply(pipeline)",
+    title="Reapply Pipeline",
     description="Re-apply environment and configuration to every package in a pipeline.",
     annotations={
         "readOnlyHint": False,
@@ -1279,7 +1279,7 @@ async def update_pipeline_tool(pipeline_id: str) -> dict:
 
 @mcp.tool(
     name="build_pipeline_env",
-    title="build(env)",
+    title="Build Environment",
     description="Rebuild a pipeline's env.yaml, capturing CMAKE_PREFIX_PATH and PATH.",
     annotations={
         "readOnlyHint": False,
@@ -1295,7 +1295,7 @@ async def build_pipeline_env_tool(pipeline_id: str) -> dict:
 
 @mcp.tool(
     name="create_pipeline",
-    title="create(pipeline)",
+    title="Create Pipeline",
     description="Create a new Jarvis-CD pipeline environment.",
     annotations={
         "readOnlyHint": False,
@@ -1311,7 +1311,7 @@ async def create_pipeline_tool(pipeline_id: str) -> dict:
 
 @mcp.tool(
     name="load_pipeline",
-    title="load(pipeline)",
+    title="Load Pipeline",
     description="Load an existing Jarvis-CD pipeline environment.",
     annotations={
         "readOnlyHint": True,
@@ -1327,7 +1327,7 @@ async def load_pipeline_tool(pipeline_id: Optional[str] = None) -> dict:
 
 @mcp.tool(
     name="export_pipeline",
-    title="export(pipeline)",
+    title="Export Pipeline",
     description="Export a structured snapshot of a Jarvis-CD pipeline.",
     annotations={
         "readOnlyHint": True,
@@ -1343,7 +1343,7 @@ async def export_pipeline_tool(pipeline_id: str, include_yaml: bool = True) -> d
 
 @mcp.tool(
     name="get_pkg_config",
-    title="get(config)",
+    title="Get Package Config",
     description="Retrieve the configuration of a specific package in a pipeline.",
     annotations={
         "readOnlyHint": True,
@@ -1359,7 +1359,7 @@ async def get_pkg_config_tool(pipeline_id: str, pkg_id: str) -> dict:
 
 @mcp.tool(
     name="append_pkg",
-    title="append(package)",
+    title="Append Package",
     description="Append a package to a Jarvis-CD pipeline.",
     annotations={
         "readOnlyHint": False,
@@ -1387,7 +1387,7 @@ async def append_pkg_tool(
 
 @mcp.tool(
     name="configure_pkg",
-    title="configure(pkg)",
+    title="Configure Package",
     description="Configure a package in a Jarvis-CD pipeline.",
     annotations={
         "readOnlyHint": False,
@@ -1405,7 +1405,7 @@ async def configure_pkg_tool(
 
 @mcp.tool(
     name="unlink_pkg",
-    title="unlink(package)",
+    title="Unlink Package",
     description="Unlink a package from a pipeline (preserve files).",
     annotations={
         "readOnlyHint": False,
@@ -1421,7 +1421,7 @@ async def unlink_pkg_tool(pipeline_id: str, pkg_id: str) -> dict:
 
 @mcp.tool(
     name="remove_pkg",
-    title="remove(package)",
+    title="Remove Package",
     description=(
         "Delete a package through JARVIS-CD's destructive removal API. Fails "
         "explicitly when the installed JARVIS-CD only supports non-destructive unlinking."
@@ -1440,7 +1440,7 @@ async def remove_pkg_tool(pipeline_id: str, pkg_id: str) -> dict:
 
 @mcp.tool(
     name="run_pipeline",
-    title="run(pipeline)",
+    title="Run Pipeline",
     description="Execute a Jarvis-CD pipeline end-to-end.",
     annotations={
         "readOnlyHint": False,
@@ -1456,7 +1456,7 @@ async def run_pipeline_tool(pipeline_id: str) -> dict:
 
 @mcp.tool(
     name="jarvis_create_pipeline",
-    title="create(jarvis run)",
+    title="Create Jarvis Run",
     description=(
         "Create a JARVIS pipeline. Optionally pass execution intent such as "
         "local, cluster, or hostfile mode; backend details are resolved where "
@@ -1483,7 +1483,7 @@ async def jarvis_create_pipeline_tool(
 
 @mcp.tool(
     name="jarvis_describe",
-    title="describe(jarvis)",
+    title="Describe",
     description=(
         "Describe JARVIS packages, one package, a pipeline, or one pipeline step. "
         "For a named application, first use target='package' with its unique short name "
@@ -1639,7 +1639,7 @@ async def jarvis_describe_tool(
 
 @mcp.tool(
     name="jarvis_add_step",
-    title="add(step)",
+    title="Add Step",
     description=(
         "Add and configure a package-backed step in a JARVIS pipeline. First use "
         "jarvis_describe(target='package') for the selected package; config keys "
@@ -1689,7 +1689,7 @@ async def jarvis_add_step_tool(
 
 @mcp.tool(
     name="jarvis_edit_step",
-    title="edit(step)",
+    title="Edit Step",
     description=(
         "Edit or remove a step in a JARVIS pipeline. Use operation='edit' with "
         "config, or operation='remove' without config."
@@ -1724,7 +1724,7 @@ async def jarvis_edit_step_tool(
 
 @mcp.tool(
     name="jarvis_run",
-    title="start(execution)",
+    title="Start Execution",
     description=(
         "Start a configured JARVIS pipeline and return its durable execution "
         "handle without waiting for workload completion. Optional execution intent "
@@ -1799,7 +1799,7 @@ async def jarvis_run_tool(
 
 @mcp.tool(
     name="jarvis_get_execution",
-    title="get(execution)",
+    title="Get Execution",
     description=(
         "Query one JARVIS execution handle, durable lifecycle record, and "
         "runtime metadata. Progress is included by default and can be omitted. "
@@ -1853,7 +1853,7 @@ def _context_has_progress_token(ctx: Context | None) -> bool:
 
 @mcp.tool(
     name="destroy_pipeline",
-    title="destroy(pipeline)",
+    title="Destroy Pipeline",
     description="Destroy a pipeline environment and clean up files.",
     annotations={
         "readOnlyHint": False,
@@ -1869,7 +1869,7 @@ async def destroy_pipeline_tool(pipeline_id: str) -> dict:
 
 @mcp.tool(
     name="jm_create_config",
-    title="init(config)",
+    title="Initialize Config",
     description="Initialize JarvisManager config directories.",
     annotations={
         "readOnlyHint": False,
@@ -1894,7 +1894,7 @@ def jm_create_config(
 
 @mcp.tool(
     name="jm_load_config",
-    title="load(config)",
+    title="Load Config",
     description="Load existing JarvisManager configuration.",
     annotations={
         "readOnlyHint": True,
@@ -1915,7 +1915,7 @@ def jm_load_config() -> list:
 
 @mcp.tool(
     name="jm_save_config",
-    title="save(config)",
+    title="Save Config",
     description="Save current JarvisManager configuration.",
     annotations={
         "readOnlyHint": False,
@@ -1936,7 +1936,7 @@ def jm_save_config() -> list:
 
 @mcp.tool(
     name="jm_set_hostfile",
-    title="set(hostfile)",
+    title="Set Hostfile",
     description="Set hostfile path for JarvisManager.",
     annotations={
         "readOnlyHint": False,
@@ -1958,7 +1958,7 @@ def jm_set_hostfile(path: str) -> list:
 
 @mcp.tool(
     name="jm_bootstrap_from",
-    title="bootstrap(machine)",
+    title="Bootstrap Machine",
     description="Bootstrap Jarvis config from a machine template.",
     annotations={
         "readOnlyHint": False,
@@ -1979,7 +1979,7 @@ def jm_bootstrap_from(machine: str) -> list:
 
 @mcp.tool(
     name="jm_bootstrap_list",
-    title="list(templates)",
+    title="List Templates",
     description="List available bootstrap machine templates.",
     annotations={
         "readOnlyHint": True,
@@ -1999,7 +1999,7 @@ def jm_bootstrap_list() -> list:
 
 @mcp.tool(
     name="jm_reset",
-    title="reset(manager)",
+    title="Reset Manager",
     description="Reset JarvisManager (destroy all pipelines and data).",
     annotations={
         "readOnlyHint": False,
@@ -2020,7 +2020,7 @@ def jm_reset() -> list:
 
 @mcp.tool(
     name="jm_list_pipelines",
-    title="list(pipelines)",
+    title="List Pipelines",
     description="List all existing Jarvis pipelines.",
     annotations={
         "readOnlyHint": True,
@@ -2041,7 +2041,7 @@ async def jm_list_pipelines() -> dict[str, Any]:
 
 @mcp.tool(
     name="jm_cd",
-    title="cd(pipeline)",
+    title="Switch Pipeline",
     description="Change current Jarvis pipeline context.",
     annotations={
         "readOnlyHint": False,
@@ -2063,7 +2063,7 @@ def jm_cd(pipeline_id: str) -> list:
 
 @mcp.tool(
     name="jm_list_repos",
-    title="list(repos)",
+    title="List Repos",
     description="List all Jarvis repositories.",
     annotations={
         "readOnlyHint": True,
@@ -2084,7 +2084,7 @@ async def jm_list_repos() -> dict[str, Any]:
 
 @mcp.tool(
     name="jm_add_repo",
-    title="add(repo)",
+    title="Add Repo",
     description="Add a repository to JarvisManager.",
     annotations={
         "readOnlyHint": False,
@@ -2106,7 +2106,7 @@ def jm_add_repo(path: str, force: bool = False) -> list:
 
 @mcp.tool(
     name="jm_remove_repo",
-    title="remove(repo)",
+    title="Remove Repo",
     description="Remove a repository from JarvisManager.",
     annotations={
         "readOnlyHint": False,
@@ -2128,7 +2128,7 @@ def jm_remove_repo(repo_name: str) -> list:
 
 @mcp.tool(
     name="jm_promote_repo",
-    title="promote(repo)",
+    title="Promote Repo",
     description="Promote a repository in JarvisManager.",
     annotations={
         "readOnlyHint": False,
@@ -2150,7 +2150,7 @@ def jm_promote_repo(repo_name: str) -> list:
 
 @mcp.tool(
     name="jm_get_repo",
-    title="get(repo)",
+    title="Get Repo",
     description="Get repository info from JarvisManager.",
     annotations={
         "readOnlyHint": True,
@@ -2171,7 +2171,7 @@ async def jm_get_repo(repo_name: str) -> dict[str, Any]:
 
 @mcp.tool(
     name="jm_construct_pkg",
-    title="construct(pkg)",
+    title="Construct Package",
     description="Construct a package skeleton in JarvisManager.",
     annotations={
         "readOnlyHint": False,
@@ -2192,7 +2192,7 @@ def jm_construct_pkg(pkg_type: str) -> list:
 
 @mcp.tool(
     name="jm_graph_show",
-    title="show(graph)",
+    title="Show Graph",
     description="Print the current resource graph frames.",
     annotations={
         "readOnlyHint": True,
@@ -2213,7 +2213,7 @@ def jm_graph_show() -> list:
 
 @mcp.tool(
     name="jm_graph_build",
-    title="build(graph)",
+    title="Build Graph",
     description="Build or rebuild the resource graph with a net sleep interval.",
     annotations={
         "readOnlyHint": False,
@@ -2234,7 +2234,7 @@ def jm_graph_build(net_sleep: float) -> list:
 
 @mcp.tool(
     name="jm_graph_modify",
-    title="modify(graph)",
+    title="Modify Graph",
     description="Modify the resource graph using a net sleep interval.",
     annotations={
         "readOnlyHint": False,

--- a/clio-kit-mcp-servers/jarvis/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_tool_titles.py
@@ -43,3 +43,17 @@ async def test_every_tool_has_a_short_title() -> None:
             assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
     finally:
         importlib.reload(server)
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    fresh_server = importlib.reload(server)
+    try:
+        async with Client(fresh_server.mcp) as client:
+            tools = await client.list_tools()
+        with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+        assert not with_parens, f"Tools with parens in title: {with_parens}"
+    finally:
+        importlib.reload(server)

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/lmod/src/lmod_mcp/server.py
+++ b/clio-kit-mcp-servers/lmod/src/lmod_mcp/server.py
@@ -35,7 +35,7 @@ mcp: FastMCP = FastMCP(
 
 @mcp.tool(
     name="module_list",
-    title="list(loaded)",
+    title="List Loaded",
     description="List all currently loaded environment modules.",
     annotations={
         "readOnlyHint": True,
@@ -54,7 +54,7 @@ async def module_list_tool() -> dict:
 
 @mcp.tool(
     name="module_avail",
-    title="search(avail)",
+    title="Search Available",
     description="Search for available modules, optionally filtered by name pattern.",
     annotations={
         "readOnlyHint": True,
@@ -73,7 +73,7 @@ async def module_avail_tool(pattern: Optional[str] = None) -> dict:
 
 @mcp.tool(
     name="module_show",
-    title="show(module)",
+    title="Show Module",
     description="Display detailed information about a specific module.",
     annotations={
         "readOnlyHint": True,
@@ -92,7 +92,7 @@ async def module_show_tool(module_name: str) -> dict:
 
 @mcp.tool(
     name="module_load",
-    title="load(modules)",
+    title="Load Modules",
     description="Load one or more environment modules into the current session.",
     annotations={
         "readOnlyHint": False,
@@ -113,7 +113,7 @@ async def module_load_tool(modules: list[str]) -> dict:
 
 @mcp.tool(
     name="module_unload",
-    title="unload(modules)",
+    title="Unload Modules",
     description="Unload one or more currently loaded modules from the environment.",
     annotations={
         "readOnlyHint": False,
@@ -134,7 +134,7 @@ async def module_unload_tool(modules: list[str]) -> dict:
 
 @mcp.tool(
     name="module_swap",
-    title="swap(module)",
+    title="Swap Module",
     description="Swap one module for another atomically.",
     annotations={
         "readOnlyHint": False,
@@ -155,7 +155,7 @@ async def module_swap_tool(old_module: str, new_module: str) -> dict:
 
 @mcp.tool(
     name="module_spider",
-    title="spider(search)",
+    title="Spider Search",
     description="Search the entire module tree comprehensively for matching modules.",
     annotations={
         "readOnlyHint": True,
@@ -174,7 +174,7 @@ async def module_spider_tool(pattern: Optional[str] = None) -> dict:
 
 @mcp.tool(
     name="module_save",
-    title="save(collection)",
+    title="Save Collection",
     description="Save currently loaded modules as a named collection.",
     annotations={
         "readOnlyHint": False,
@@ -195,7 +195,7 @@ async def module_save_tool(collection_name: str) -> dict:
 
 @mcp.tool(
     name="module_restore",
-    title="restore(collection)",
+    title="Restore Collection",
     description="Restore a previously saved module collection.",
     annotations={
         "readOnlyHint": False,
@@ -216,7 +216,7 @@ async def module_restore_tool(collection_name: str) -> dict:
 
 @mcp.tool(
     name="module_savelist",
-    title="list(collections)",
+    title="List Collections",
     description="List all saved module collections.",
     annotations={
         "readOnlyHint": True,

--- a/clio-kit-mcp-servers/lmod/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/lmod/tests/test_tool_titles.py
@@ -15,3 +15,14 @@ async def test_all_tools_have_compact_titles() -> None:
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/src/ndp_mcp/server.py
+++ b/clio-kit-mcp-servers/ndp/src/ndp_mcp/server.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Annotated, Any, Literal, TypedDict, cast
+from typing import Annotated, Any, Literal, cast
 
 import httpx
 from dotenv import load_dotenv
@@ -11,7 +11,7 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.prompts import Message
 from pydantic import BaseModel, Field
-from typing_extensions import NotRequired
+from typing_extensions import NotRequired, TypedDict
 
 # Environment setup
 load_dotenv()

--- a/clio-kit-mcp-servers/ndp/src/ndp_mcp/server.py
+++ b/clio-kit-mcp-servers/ndp/src/ndp_mcp/server.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal, TypedDict, cast
 
 import httpx
 from dotenv import load_dotenv
@@ -11,6 +11,7 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.prompts import Message
 from pydantic import BaseModel, Field
+from typing_extensions import NotRequired
 
 # Environment setup
 load_dotenv()
@@ -213,6 +214,87 @@ class Dataset(BaseModel):
     extras: dict[str, Any] | None = None
 
 
+# --- Structured result shapes (drive real MCP outputSchema declarations) ----
+
+
+class ToolMeta(TypedDict):
+    """Per-call diagnostic metadata echoed back on every NDP tool response."""
+
+    tool: str
+    status: str
+
+
+class ListOrganizationsResult(TypedDict):
+    """Structured result for a successful organizations listing."""
+
+    organizations: list[str]
+    count: int
+    server: str
+    name_filter: str | None
+    _meta: ToolMeta
+
+
+class SearchParameters(TypedDict):
+    """Echo of the request parameters that produced a search result set."""
+
+    search_terms: list[str] | None
+    search_keys: list[str] | None
+    dataset_name: str | None
+    dataset_title: str | None
+    owner_org: str | None
+    resource_format: str | None
+    search_term: str | None
+    filter_list: list[str] | None
+    limit: int | str | None
+
+
+class SearchDatasetsResult(TypedDict):
+    """Structured result for a dataset search."""
+
+    datasets: list[Dataset]
+    count: int
+    total_found: int | str
+    server: str
+    search_parameters: SearchParameters
+    _meta: ToolMeta
+
+
+class DatasetIdentifier(TypedDict):
+    """Which identifier field and value resolved the returned dataset."""
+
+    type: str
+    value: str
+
+
+class GetDatasetDetailsResult(TypedDict):
+    """Structured result for a single dataset's detailed metadata."""
+
+    dataset: Dataset
+    identifier_used: DatasetIdentifier
+    server: str
+    resource_count: int
+    _meta: ToolMeta
+
+
+class StageResourceResult(TypedDict):
+    """Structured result for a staged dataset resource (HTTP or OSDF/Pelican).
+
+    Both staging paths populate ``ok``, ``local_path``, ``size_bytes``,
+    ``content_type``, ``url``, and ``method``. ``transport`` is present only
+    on the OSDF/Pelican path; ``_meta`` is present only on the direct-HTTP(S)
+    path.
+    """
+
+    ok: Literal[True]
+    local_path: str
+    size_bytes: int
+    content_type: str | None
+    url: str
+    method: Literal["http", "pelican"]
+    transport: NotRequired[Literal["osdf"]]
+    _meta: NotRequired[ToolMeta]
+
+
 class NDPClient:
     """Client for interacting with NDP API with retry logic and error handling."""
 
@@ -348,7 +430,7 @@ ndp_client = NDPClient()
 
 @mcp.tool(
     name="list_organizations",
-    title="list(orgs)",
+    title="List Organizations",
     description="List organizations available in the National Data Platform.",
     annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
     tags={"organizations", "catalogs"},
@@ -360,7 +442,7 @@ async def list_organizations(
     server: Annotated[
         str, Field(description="Server to query: 'local', 'global', or 'pre_ckan'")
     ] = "global",
-) -> dict[str, Any]:
+) -> ListOrganizationsResult:
     """List organizations from the National Data Platform."""
     try:
         organizations = await ndp_client.list_organizations(name_filter, server)
@@ -378,7 +460,7 @@ async def list_organizations(
 
 @mcp.tool(
     name="search_datasets",
-    title="search(datasets)",
+    title="Search Datasets",
     description="Search for datasets in the NDP using term-based or field-specific criteria.",
     annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
     tags={"datasets", "search"},
@@ -419,7 +501,7 @@ async def search_datasets(
     limit: Annotated[
         str | int | None, Field(description="Maximum results to return (default: 20)")
     ] = None,
-) -> dict[str, Any]:
+) -> SearchDatasetsResult:
     """Search for datasets in the National Data Platform."""
     try:
         # Determine which search method to use
@@ -465,33 +547,36 @@ async def search_datasets(
         # Convert datasets to dict format
         dataset_dicts = [dataset.model_dump() for dataset in datasets]
 
-        return {
-            "datasets": dataset_dicts,
-            "count": len(dataset_dicts),
-            "total_found": total_found
-            if not was_limited
-            else f"{len(dataset_dicts)} of {total_found}",
-            "server": server,
-            "search_parameters": {
-                "search_terms": search_terms,
-                "search_keys": search_keys,
-                "dataset_name": dataset_name,
-                "dataset_title": dataset_title,
-                "owner_org": owner_org,
-                "resource_format": resource_format,
-                "search_term": search_term,
-                "filter_list": filter_list,
-                "limit": limit,
+        return cast(
+            SearchDatasetsResult,
+            {
+                "datasets": dataset_dicts,
+                "count": len(dataset_dicts),
+                "total_found": total_found
+                if not was_limited
+                else f"{len(dataset_dicts)} of {total_found}",
+                "server": server,
+                "search_parameters": {
+                    "search_terms": search_terms,
+                    "search_keys": search_keys,
+                    "dataset_name": dataset_name,
+                    "dataset_title": dataset_title,
+                    "owner_org": owner_org,
+                    "resource_format": resource_format,
+                    "search_term": search_term,
+                    "filter_list": filter_list,
+                    "limit": limit,
+                },
+                "_meta": {"tool": "search_datasets", "status": "success"},
             },
-            "_meta": {"tool": "search_datasets", "status": "success"},
-        }
+        )
     except Exception as e:
         raise ToolError(str(e)) from e
 
 
 @mcp.tool(
     name="get_dataset_details",
-    title="get(dataset)",
+    title="Dataset Details",
     description="Retrieve detailed metadata for a specific dataset by ID or name.",
     annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
     tags={"datasets", "metadata"},
@@ -502,7 +587,7 @@ async def get_dataset_details(
     ],
     identifier_type: Annotated[str, Field(description="Type of identifier: 'id' or 'name'")] = "id",
     server: Annotated[str, Field(description="Server to query: 'local' or 'global'")] = "global",
-) -> dict[str, Any]:
+) -> GetDatasetDetailsResult:
     """Get detailed information about a specific dataset."""
     try:
         # Search for the specific dataset
@@ -521,13 +606,16 @@ async def get_dataset_details(
         # Return detailed dataset information
         dataset_dict = matching_dataset.model_dump()
 
-        return {
-            "dataset": dataset_dict,
-            "identifier_used": {"type": identifier_type, "value": dataset_identifier},
-            "server": server,
-            "resource_count": len(dataset_dict.get("resources", [])),
-            "_meta": {"tool": "get_dataset_details", "status": "success"},
-        }
+        return cast(
+            GetDatasetDetailsResult,
+            {
+                "dataset": dataset_dict,
+                "identifier_used": {"type": identifier_type, "value": dataset_identifier},
+                "server": server,
+                "resource_count": len(dataset_dict.get("resources", [])),
+                "_meta": {"tool": "get_dataset_details", "status": "success"},
+            },
+        )
     except ToolError:
         raise
     except Exception as e:
@@ -536,7 +624,7 @@ async def get_dataset_details(
 
 @mcp.tool(
     name="stage_resource",
-    title="stage(resource)",
+    title="Stage Resource",
     description=(
         "Download/stage an HTTP(S) or OSDF/Pelican dataset resource to a local "
         "file and return its local_path, size, and content-type."
@@ -570,7 +658,7 @@ async def stage_resource(
         int | str | None,
         Field(description="Advertised resource size (bytes or '1.4 GB') for OSDF size checks."),
     ] = None,
-) -> dict[str, Any]:
+) -> StageResourceResult:
     """Stage a dataset resource to the configurable artifacts root.
 
     HTTP(S) resources are streamed with a size cap. ``osdf://`` resources are
@@ -593,12 +681,15 @@ async def stage_resource(
 
     is_osdf = target_url.lower().startswith("osdf://")
     if is_osdf:
-        return await asyncio.to_thread(
-            _stage_pelican_resource,
-            url=target_url,
-            output_path=output_path,
-            max_bytes=max_stage_bytes,
-            resource_size_bytes=_parse_resource_size_bytes(resource_size_bytes),
+        return cast(
+            StageResourceResult,
+            await asyncio.to_thread(
+                _stage_pelican_resource,
+                url=target_url,
+                output_path=output_path,
+                max_bytes=max_stage_bytes,
+                resource_size_bytes=_parse_resource_size_bytes(resource_size_bytes),
+            ),
         )
 
     timeout = httpx.Timeout(_HTTP_READ_TIMEOUT_S, connect=_HTTP_CONNECT_TIMEOUT_S)

--- a/clio-kit-mcp-servers/ndp/tests/test_data_retrieval_tools.py
+++ b/clio-kit-mcp-servers/ndp/tests/test_data_retrieval_tools.py
@@ -18,6 +18,15 @@ from ndp_mcp.server import mcp
 
 
 def _parse_result(result: Any) -> dict[str, Any]:
+    # Now that stage_resource declares a real, field-level outputSchema
+    # (2.7.1), the in-memory client validates ``result.data`` into a
+    # generated typed model rather than handing back a plain dict.
+    # ``structured_content`` is always the raw JSON-able dict the tool
+    # actually returned, independent of that client-side typing, so prefer
+    # it before falling back to the ``.data`` shapes used pre-outputSchema.
+    structured = getattr(result, "structured_content", None)
+    if isinstance(structured, dict):
+        return structured
     data = result.data
     if isinstance(data, dict):
         return data

--- a/clio-kit-mcp-servers/ndp/tests/test_output_schemas.py
+++ b/clio-kit-mcp-servers/ndp/tests/test_output_schemas.py
@@ -1,0 +1,107 @@
+"""Verify NDP tools declare real MCP output semantics (2026-07-28 protocol).
+
+Every NDP tool's registration must advertise a real, field-level
+``outputSchema`` — not the generic ``{"type": "object"}`` a bare
+``-> dict[str, Any]`` return annotation would produce.
+
+These tests drive the server through an in-memory ``fastmcp.Client``, so they
+exercise exactly what a real MCP client sees on the wire.
+"""
+
+import pytest
+from fastmcp import Client
+
+from ndp_mcp.server import mcp
+
+ALL_TOOL_NAMES = {
+    "list_organizations",
+    "search_datasets",
+    "get_dataset_details",
+    "stage_resource",
+}
+
+# Field names that must always be present in each tool's outputSchema
+# properties, regardless of which runtime branch produced the result.
+EXPECTED_FIELDS = {
+    "list_organizations": {"organizations", "count", "server", "name_filter"},
+    "search_datasets": {"datasets", "count", "total_found", "server", "search_parameters"},
+    "get_dataset_details": {"dataset", "identifier_used", "server", "resource_count"},
+    "stage_resource": {"ok", "local_path", "size_bytes", "content_type", "url", "method"},
+}
+
+
+@pytest.mark.asyncio
+async def test_tools_list_advertises_real_output_schemas() -> None:
+    """tools/list must show a field-level outputSchema for every NDP tool."""
+    async with Client(mcp) as client:
+        tools = {tool.name: tool for tool in await client.list_tools()}
+
+    missing = ALL_TOOL_NAMES - set(tools)
+    assert not missing, f"tools missing from tools/list: {missing}"
+
+    for name in ALL_TOOL_NAMES:
+        schema = tools[name].output_schema
+        assert schema is not None, f"{name} has no outputSchema"
+        assert schema.get("type") == "object", f"{name} outputSchema is not an object"
+        properties = schema.get("properties")
+        assert properties, f"{name} outputSchema has no real field properties: {schema}"
+
+        expected = EXPECTED_FIELDS[name]
+        missing_fields = expected - set(properties)
+        assert not missing_fields, (
+            f"{name} outputSchema missing expected fields {missing_fields}: {schema}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_organizations_schema_is_not_generic() -> None:
+    """The bare-dict fallback schema ({"type": "object", "additionalProperties":
+    true} with no real "properties") must not survive for list_organizations."""
+    async with Client(mcp) as client:
+        tools = {tool.name: tool for tool in await client.list_tools()}
+
+    schema = tools["list_organizations"].output_schema
+    assert schema is not None
+    assert "organizations" in schema["properties"]
+    assert schema["properties"]["count"].get("type") == "integer"
+
+
+@pytest.mark.asyncio
+async def test_search_datasets_schema_has_nested_search_parameters() -> None:
+    """search_parameters must be a real nested object schema, not a bare dict."""
+    async with Client(mcp) as client:
+        tools = {tool.name: tool for tool in await client.list_tools()}
+
+    schema = tools["search_datasets"].output_schema
+    assert schema is not None
+    search_parameters = schema["properties"]["search_parameters"]
+    # Resolve a top-level $ref (e.g. "#/$defs/SearchParameters") if present.
+    if "$ref" in search_parameters:
+        ref = search_parameters["$ref"].removeprefix("#/")
+        target: dict = schema
+        for segment in ref.split("/"):
+            target = target[segment]
+        search_parameters = target
+    assert search_parameters.get("properties"), (
+        f"search_parameters has no field-level schema: {search_parameters}"
+    )
+    assert "dataset_name" in search_parameters["properties"]
+
+
+@pytest.mark.asyncio
+async def test_stage_resource_schema_covers_both_success_paths() -> None:
+    """stage_resource is reachable via HTTP and OSDF/Pelican paths; the
+    outputSchema must cover the fields common to both, truthfully."""
+    async with Client(mcp) as client:
+        tools = {tool.name: tool for tool in await client.list_tools()}
+
+    schema = tools["stage_resource"].output_schema
+    assert schema is not None
+    properties = schema["properties"]
+    for field in ("ok", "local_path", "size_bytes", "content_type", "url", "method"):
+        assert field in properties, f"stage_resource outputSchema missing '{field}': {schema}"
+
+    required = set(schema.get("required", []))
+    # Path-specific fields must not be forced required on both branches.
+    assert "transport" not in required
+    assert "_meta" not in required

--- a/clio-kit-mcp-servers/ndp/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/ndp/tests/test_tool_titles.py
@@ -40,3 +40,14 @@ async def test_titles_are_distinct_within_server() -> None:
 
     titles = [tool.title for tool in tools]
     assert len(titles) == len(set(titles)), "Duplicate titles found within ndp server"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/src/node_hardware_mcp/server.py
+++ b/clio-kit-mcp-servers/node-hardware/src/node_hardware_mcp/server.py
@@ -64,7 +64,7 @@ _READ_ONLY_ANNOTATIONS = {
 
 @mcp.tool(
     name="get_cpu_info",
-    title="get(cpu)",
+    title="CPU Info",
     description="Get CPU specifications, core counts, frequencies, and per-core usage.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"hardware", "cpu"},
@@ -81,7 +81,7 @@ async def get_cpu_info_tool() -> dict:
 
 @mcp.tool(
     name="get_memory_info",
-    title="get(memory)",
+    title="Memory Info",
     description="Get RAM and swap capacity, usage percentages, and availability.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"hardware", "memory"},
@@ -98,7 +98,7 @@ async def get_memory_info_tool() -> dict:
 
 @mcp.tool(
     name="get_system_info",
-    title="get(system)",
+    title="System Info",
     description="Get OS details, hostname, uptime, and active users.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"hardware", "system"},
@@ -115,7 +115,7 @@ async def get_system_info_tool() -> dict:
 
 @mcp.tool(
     name="get_disk_info",
-    title="get(disk)",
+    title="Disk Info",
     description="Get disk partitions, usage statistics, and I/O counters.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"hardware", "disk"},
@@ -132,7 +132,7 @@ async def get_disk_info_tool() -> dict:
 
 @mcp.tool(
     name="get_network_info",
-    title="get(network)",
+    title="Network Info",
     description="Get network interfaces, IP addresses, and I/O statistics.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"hardware", "network"},
@@ -149,7 +149,7 @@ async def get_network_info_tool() -> dict:
 
 @mcp.tool(
     name="get_gpu_info",
-    title="get(gpu)",
+    title="GPU Info",
     description="Get GPU model, memory, temperature, and utilization via nvidia-smi/rocm-smi.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"hardware", "gpu"},
@@ -166,7 +166,7 @@ async def get_gpu_info_tool() -> dict:
 
 @mcp.tool(
     name="get_sensor_info",
-    title="get(sensors)",
+    title="Sensor Info",
     description="Get temperature, fan speed, and battery sensor readings.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"hardware", "sensor"},
@@ -183,7 +183,7 @@ async def get_sensor_info_tool() -> dict:
 
 @mcp.tool(
     name="get_process_info",
-    title="get(processes)",
+    title="Process Info",
     description="Get running processes with CPU, memory, and status details.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"hardware", "process"},
@@ -200,7 +200,7 @@ async def get_process_info_tool() -> dict:
 
 @mcp.tool(
     name="get_performance_info",
-    title="get(performance)",
+    title="Performance Info",
     description="Get real-time CPU, memory, disk, and network performance metrics.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"hardware", "performance"},
@@ -222,7 +222,7 @@ async def get_performance_info_tool() -> dict:
 
 @mcp.tool(
     name="get_remote_node_info",
-    title="get(remote node)",
+    title="Remote Node Info",
     description="Collect hardware info from a remote node via SSH. Supports component filtering.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"hardware", "remote", "ssh"},
@@ -279,7 +279,7 @@ async def get_remote_node_info_tool(
 
 @mcp.tool(
     name="health_check",
-    title="check(health)",
+    title="Health Check",
     description="Verify server health and hardware monitoring capability status.",
     annotations=_READ_ONLY_ANNOTATIONS,
     tags={"hardware", "diagnostics"},

--- a/clio-kit-mcp-servers/node-hardware/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/node-hardware/tests/test_tool_titles.py
@@ -41,3 +41,14 @@ async def test_titles_are_distinct_within_server() -> None:
     assert len(titles) == len(set(titles)), (
         "Duplicate titles found within node-hardware server"
     )
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/src/pandas_mcp/server.py
+++ b/clio-kit-mcp-servers/pandas/src/pandas_mcp/server.py
@@ -8,12 +8,13 @@ hypothesis testing on various data formats.
 
 import os
 import logging
-from typing import Annotated, Optional, List, Any, Dict
+from typing import Annotated, Optional, List, Any, Dict, Literal, cast
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.prompts import Message
 from pydantic import Field
+from typing_extensions import NotRequired, TypedDict
 
 try:
     from dotenv import load_dotenv
@@ -39,6 +40,520 @@ from .implementation.time_series import time_series_operations
 from .implementation.memory_optimization import optimize_memory_usage
 from .implementation.filtering import filter_data
 from .implementation.validation import validate_data, hypothesis_testing
+
+
+# --- Structured result shapes (drive real MCP outputSchema declarations) ----
+#
+# Every TypedDict below types the SUCCESS-path dict actually returned by its
+# implementation function (traced from the real `return {...}` statements,
+# not from docstrings). Tool handlers raise `ToolError` on failure, so the
+# error-path shape (`success: False`, `error`, `error_type`, ...) is
+# deliberately not modeled here. Fields whose keys are data-dependent (e.g.
+# column names) are typed `dict[str, <precise value type>]` where the value
+# type is uniform, and fall back to `dict[str, Any]` only where the value
+# shape genuinely varies (e.g. a per-test-type hypothesis test_info dict, or
+# a raw record dict where each column may hold any type).
+
+
+class LoadDataInfo(TypedDict):
+    """Schema/shape metadata attached to a successful data load."""
+
+    shape: tuple[int, int]
+    columns: list[str]
+    dtypes: dict[str, str]
+    memory_usage: int
+    missing_values: dict[str, int]
+
+
+class LoadDataResult(TypedDict):
+    """Structured result for a successful data load."""
+
+    success: Literal[True]
+    file_path: str
+    file_format: str
+    data: list[dict[str, Any]]
+    total_rows: int
+    info: LoadDataInfo
+    message: str
+
+
+class SaveDataResult(TypedDict):
+    """Structured result for a successful data save."""
+
+    success: Literal[True]
+    file_path: str
+    file_format: str
+    file_size_bytes: int
+    file_size_mb: float
+    rows_saved: int
+    columns_saved: int
+    message: str
+
+
+class NormalityTestResult(TypedDict):
+    """Shapiro-Wilk normality test result for one numeric column."""
+
+    shapiro_wilk_statistic: float
+    shapiro_wilk_p_value: float
+    is_normal: bool
+
+
+class ColumnAdditionalStats(TypedDict):
+    """Extra distribution statistics for one numeric column."""
+
+    variance: float
+    skewness: float
+    kurtosis: float
+    median_absolute_deviation: float
+    interquartile_range: float
+    coefficient_of_variation: float | None
+    normality_test: NotRequired[NormalityTestResult]
+
+
+class ColumnCategoricalStats(TypedDict):
+    """Categorical summary statistics for one column."""
+
+    unique_values: int
+    most_frequent: str | None
+    most_frequent_count: int
+    value_counts: dict[str, int]
+
+
+class MissingDataSummary(TypedDict):
+    """Missing-value counts for a dataset."""
+
+    total_missing: int
+    missing_by_column: dict[str, int]
+    missing_percentage: dict[str, float]
+
+
+class StatisticalSummaryResult(TypedDict):
+    """Structured result for a successful statistical summary."""
+
+    success: Literal[True]
+    file_path: str
+    shape: tuple[int, int]
+    basic_statistics: dict[str, dict[str, Any]]
+    additional_statistics: dict[str, ColumnAdditionalStats]
+    categorical_statistics: dict[str, ColumnCategoricalStats]
+    missing_data: MissingDataSummary
+    message: str
+
+
+class HighCorrelationPair(TypedDict):
+    """One strongly correlated variable pair."""
+
+    variable1: str
+    variable2: str
+    correlation: float
+    strength: Literal["strong", "moderate"]
+
+
+class CorrelationAnalysisResult(TypedDict):
+    """Structured result for a successful correlation analysis."""
+
+    success: Literal[True]
+    file_path: str
+    method: str
+    correlation_matrix: dict[str, dict[str, float]]
+    high_correlations: list[HighCorrelationPair]
+    analyzed_columns: list[str]
+    message: str
+
+
+class HypothesisTestInterpretation(TypedDict):
+    """Statistical interpretation shared by every hypothesis test type."""
+
+    statistic: float
+    p_value: float
+    alpha: float
+    is_significant: bool
+    conclusion: Literal["Reject null hypothesis", "Fail to reject null hypothesis"]
+    effect_size: Literal["large", "medium", "small"]
+
+
+class HypothesisTestingResult(TypedDict):
+    """Structured result for a successful hypothesis test.
+
+    ``test_info`` is a discriminated union keyed by ``test_type`` (t-test,
+    chi-square, correlation, ANOVA, ...); each variant has its own field set
+    and value types, so it is left as ``dict[str, Any]`` rather than forcing
+    a false shared shape.
+    """
+
+    success: Literal[True]
+    file_path: str
+    test_info: dict[str, Any]
+    results: HypothesisTestInterpretation
+    message: str
+
+
+class MissingDataInfo(TypedDict):
+    """Missing-value counts, plus row-level missing-data coverage."""
+
+    total_missing: int
+    missing_by_column: dict[str, int]
+    missing_percentage: dict[str, float]
+    rows_with_missing: int
+    complete_rows: int
+
+
+class ImputationColumnInfo(TypedDict):
+    """Per-column imputation method and outcome."""
+
+    method: str
+    fill_value: float | str
+    imputed_count: int
+
+
+class HandleMissingDataResult(TypedDict):
+    """Structured result for a successful missing-data handling call.
+
+    Field presence depends on ``strategy``: ``detect`` returns only
+    ``original_shape``/``missing_data_info``; ``remove`` and ``impute`` also
+    write an output file and add their own strategy-specific fields.
+    """
+
+    success: Literal[True]
+    file_path: str
+    original_shape: tuple[int, int]
+    missing_data_info: MissingDataInfo
+    message: str
+    output_file: NotRequired[str]
+    new_shape: NotRequired[tuple[int, int]]
+    removed_rows: NotRequired[int]
+    imputation_method: NotRequired[str]
+    imputation_info: NotRequired[dict[str, ImputationColumnInfo]]
+
+
+class OutlierColumnInfo(TypedDict):
+    """IQR-based outlier statistics for one numeric column."""
+
+    outlier_count: int
+    outlier_percentage: float
+    lower_bound: float
+    upper_bound: float
+    outlier_values: list[float]
+
+
+class CleaningResults(TypedDict):
+    """Nested cleaning statistics for a successful clean_data call."""
+
+    original_shape: tuple[int, int]
+    original_memory_mb: float
+    final_shape: tuple[int, int]
+    final_memory_mb: float
+    memory_reduction_mb: float
+    outliers_info: dict[str, OutlierColumnInfo] | None
+    type_changes: dict[str, str] | None
+    duplicates_removed: NotRequired[int]
+
+
+class CleanDataResult(TypedDict):
+    """Structured result for a successful data cleaning call."""
+
+    success: Literal[True]
+    file_path: str
+    output_file: str
+    cleaning_results: CleaningResults
+    message: str
+
+
+class GroupByInfo(TypedDict):
+    """Parameters and outcome summary of a groupby aggregation."""
+
+    group_by_columns: list[str]
+    operations: dict[str, str]
+    filter_condition: str | None
+    number_of_groups: int
+    original_rows: int
+    aggregated_columns: list[str]
+
+
+class GroupByOperationsResult(TypedDict):
+    """Structured result for a successful groupby operation."""
+
+    success: Literal[True]
+    file_path: str
+    output_file: str
+    group_info: GroupByInfo
+    results: list[dict[str, Any]]
+    message: str
+
+
+class MergeStats(TypedDict):
+    """Row/column shape and join-key coverage for a dataset merge."""
+
+    left_shape: tuple[int, int]
+    right_shape: tuple[int, int]
+    merged_shape: tuple[int, int]
+    join_type: str
+    left_on: str
+    right_on: str
+    common_values: int
+    left_only_values: int
+    right_only_values: int
+
+
+class MergeDatasetsResult(TypedDict):
+    """Structured result for a successful dataset merge."""
+
+    success: Literal[True]
+    left_file: str
+    right_file: str
+    output_file: str
+    merge_stats: MergeStats
+    merged_data: list[dict[str, Any]]
+    message: str
+
+
+class PivotInfo(TypedDict):
+    """Parameters and shape summary for a created pivot table."""
+
+    index_columns: list[str]
+    column_headers: list[str] | None
+    value_columns: list[str] | None
+    aggregation_function: str
+    pivot_shape: tuple[int, int]
+    original_shape: tuple[int, int]
+
+
+class PivotTableResult(TypedDict):
+    """Structured result for a successful pivot table creation."""
+
+    success: Literal[True]
+    file_path: str
+    output_file: str
+    pivot_info: PivotInfo
+    pivot_table: list[dict[str, Any]]
+    message: str
+
+
+class TimeSeriesOperationsResult(TypedDict):
+    """Structured result for a successful time-series operation.
+
+    ``operation_info`` varies by ``operation`` (resample/rolling/lag/diff,
+    each with its own field set), so it is left as ``dict[str, Any]``.
+    """
+
+    success: Literal[True]
+    file_path: str
+    output_file: str
+    operation_info: dict[str, Any]
+    results: list[dict[str, Any]]
+    message: str
+
+
+class ValidationSummary(TypedDict):
+    """Aggregate pass/fail counts across all validated columns."""
+
+    overall_valid: bool
+    total_columns_validated: int
+    valid_columns: int
+    invalid_columns: int
+    total_violations: int
+
+
+class ValidateDataResult(TypedDict):
+    """Structured result for a successful data validation run.
+
+    ``validation_results`` is keyed by column name; each entry's shape
+    depends on which rules were violated (different rule types report
+    different fields), so its value type is left as ``dict[str, Any]``.
+    """
+
+    success: Literal[True]
+    file_path: str
+    validation_summary: ValidationSummary
+    validation_results: dict[str, dict[str, Any]]
+    message: str
+
+
+class FilterStats(TypedDict):
+    """Row-count and per-filter statistics for a filter_data call."""
+
+    original_shape: tuple[int, int]
+    final_shape: tuple[int, int]
+    rows_filtered: int
+    filter_percentage: float
+    applied_filters: list[dict[str, Any]]
+
+
+class FilterDataResult(TypedDict):
+    """Structured result for a successful data filtering call."""
+
+    success: Literal[True]
+    file_path: str
+    output_file: str
+    filter_stats: FilterStats
+    filtered_data: list[dict[str, Any]]
+    message: str
+
+
+class SystemMemoryInfo(TypedDict):
+    """Host system memory snapshot taken during an optimize_memory call."""
+
+    total_gb: float
+    available_gb: float
+    percent_used: float
+
+
+class MemoryOptimizationSummary(TypedDict):
+    """Before/after memory footprint for a successful optimization."""
+
+    initial_memory_mb: float
+    final_memory_mb: float
+    memory_reduction_mb: float
+    memory_reduction_percentage: float
+    shape: tuple[int, int]
+
+
+class ColumnMemoryInfo(TypedDict):
+    """Per-column memory footprint after optimization."""
+
+    memory_mb: float
+    dtype: str
+    percentage_of_total: float
+
+
+class OptimizationLogEntry(TypedDict):
+    """One optimization pass recorded in the optimization log."""
+
+    optimization: str
+    changes: dict[str, str]
+
+
+class OptimizationLog(TypedDict):
+    """Log of optimization passes applied to the DataFrame."""
+
+    initial_memory_mb: float
+    initial_shape: tuple[int, int]
+    optimizations_applied: list[OptimizationLogEntry]
+
+
+class OptimizeMemoryResult(TypedDict):
+    """Structured result for a successful memory optimization call.
+
+    ``chunked_processing`` is only computed when ``chunk_size`` is given, and
+    its helper has its own independent success/error shape, so it is left as
+    ``dict[str, Any] | None`` rather than a forced single shape.
+    """
+
+    success: Literal[True]
+    file_path: str
+    output_file: str
+    system_memory: SystemMemoryInfo
+    optimization_results: MemoryOptimizationSummary
+    column_memory_usage: dict[str, ColumnMemoryInfo]
+    optimization_log: OptimizationLog
+    chunked_processing: dict[str, Any] | None
+    recommendations: list[str]
+    message: str
+
+
+class ProfileBasicInfo(TypedDict):
+    """Shape and dtype snapshot of the profiled dataset."""
+
+    shape: tuple[int, int]
+    columns: list[str]
+    dtypes: dict[str, str]
+    memory_usage_mb: float
+
+
+class ProfileMissingData(TypedDict):
+    """Missing-value counts and affected columns for a profiled dataset."""
+
+    total_missing: int
+    missing_by_column: dict[str, int]
+    missing_percentage: dict[str, float]
+    columns_with_missing: list[str]
+    complete_rows: int
+
+
+class ProfileQualityChecks(TypedDict):
+    """Structural data-quality flags found during profiling."""
+
+    duplicate_rows: int
+    constant_columns: list[str]
+    high_cardinality_columns: list[str]
+    mixed_type_columns: list[str]
+
+
+class ProfileHighCorrelation(TypedDict):
+    """One strongly correlated variable pair found during profiling."""
+
+    variable1: str
+    variable2: str
+    correlation: float
+
+
+class ProfileCorrelations(TypedDict):
+    """Correlation matrix and notable pairs computed during profiling."""
+
+    correlation_matrix: dict[str, dict[str, float]]
+    high_correlations: list[ProfileHighCorrelation]
+
+
+class ProfileSummary(TypedDict):
+    """High-level counts summarizing a data profile."""
+
+    total_columns: int
+    numeric_columns: int
+    categorical_columns: int
+    datetime_columns: int
+    total_rows: int
+    complete_rows: int
+    duplicate_rows: int
+    memory_usage_mb: float
+
+
+class ProfileDataResult(TypedDict):
+    """Structured result for a successful data profiling call.
+
+    ``column_analysis`` is keyed by column name; each entry's shape depends
+    on the column's inferred type (numeric/categorical/datetime), so its
+    value type is left as ``dict[str, Any]``.
+    """
+
+    success: Literal[True]
+    file_path: str
+    basic_info: ProfileBasicInfo
+    summary: ProfileSummary
+    missing_data: ProfileMissingData
+    column_analysis: dict[str, dict[str, Any]]
+    quality_checks: ProfileQualityChecks
+    correlations: ProfileCorrelations | None
+    message: str
+
+
+class CsvNumericSummary(TypedDict):
+    """Min/max/mean summary for one numeric CSV column."""
+
+    count: int
+    min: float
+    max: float
+    mean: float
+
+
+class ProfileCsvResult(TypedDict):
+    """Structured result for a successful profile_csv call."""
+
+    success: Literal[True]
+    file_path: str
+    size_bytes: int
+    columns: list[str]
+    column_count: int
+    row_count: int
+    rows_profiled: int
+    row_scan_cap: int
+    scan_limited: bool
+    profile_limited: bool
+    dtypes: dict[str, Literal["empty", "integer", "float", "boolean", "string"]]
+    null_counts: dict[str, int]
+    numeric_summary: dict[str, CsvNumericSummary]
+    sample_rows: list[dict[str, str]]
+    message: str
+
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -70,7 +585,7 @@ class PandasMCPError(Exception):
 
 @mcp.tool(
     name="load_data",
-    title="load(data)",
+    title="Load Data",
     description="Load and parse data from CSV, Excel, JSON, Parquet, or HDF5 files with optional column selection and row limiting.",
     annotations={
         "readOnlyHint": True,
@@ -103,12 +618,15 @@ async def load_data_tool(
     nrows: Annotated[
         Optional[int], Field(description="Maximum rows to load; None loads all")
     ] = None,
-) -> dict:
+) -> LoadDataResult:
     """Load data from various file formats with comprehensive parsing options."""
     try:
         logger.info(f"Loading data from: {file_path}")
-        return load_data_file(
-            file_path, file_format, sheet_name, encoding, columns, nrows
+        return cast(
+            LoadDataResult,
+            load_data_file(
+                file_path, file_format, sheet_name, encoding, columns, nrows
+            ),
         )
     except Exception as e:
         logger.error(f"Data loading error: {e}")
@@ -117,7 +635,7 @@ async def load_data_tool(
 
 @mcp.tool(
     name="save_data",
-    title="save(data)",
+    title="Save Data",
     description="Save data to CSV, Excel, JSON, Parquet, or HDF5 with auto-detected format and optional index inclusion.",
     annotations={
         "readOnlyHint": False,
@@ -142,11 +660,11 @@ async def save_data_tool(
     index: Annotated[
         bool, Field(description="Whether to include row indices in output")
     ] = True,
-) -> dict:
+) -> SaveDataResult:
     """Save data to various file formats with comprehensive export options."""
     try:
         logger.info(f"Saving data to: {file_path}")
-        return save_data_file(data, file_path, file_format, index)
+        return cast(SaveDataResult, save_data_file(data, file_path, file_format, index))
     except Exception as e:
         logger.error(f"Data saving error: {e}")
         raise ToolError(f"Data saving error: {e}") from e
@@ -159,7 +677,7 @@ async def save_data_tool(
 
 @mcp.tool(
     name="statistical_summary",
-    title="summary(stats)",
+    title="Statistical Summary",
     description="Compute descriptive statistics, distribution analysis, and outlier detection for numerical and categorical columns.",
     annotations={
         "readOnlyHint": True,
@@ -177,11 +695,14 @@ async def statistical_summary_tool(
     include_distributions: Annotated[
         bool, Field(description="Include distribution analysis and normality tests")
     ] = False,
-) -> dict:
+) -> StatisticalSummaryResult:
     """Generate comprehensive statistical summary with advanced analytics."""
     try:
         logger.info(f"Generating statistical summary for: {file_path}")
-        return get_statistical_summary(file_path, columns, include_distributions)
+        return cast(
+            StatisticalSummaryResult,
+            get_statistical_summary(file_path, columns, include_distributions),
+        )
     except Exception as e:
         logger.error(f"Statistical analysis error: {e}")
         raise ToolError(f"Statistical analysis error: {e}") from e
@@ -189,7 +710,7 @@ async def statistical_summary_tool(
 
 @mcp.tool(
     name="correlation_analysis",
-    title="correlate(data)",
+    title="Correlation Analysis",
     description="Compute correlation matrices (Pearson, Spearman, or Kendall) with significance testing and strong-correlation detection.",
     annotations={
         "readOnlyHint": True,
@@ -207,11 +728,14 @@ async def correlation_analysis_tool(
         Optional[List[str]],
         Field(description="Columns to analyze; None analyzes all numerical columns"),
     ] = None,
-) -> dict:
+) -> CorrelationAnalysisResult:
     """Perform comprehensive correlation analysis with statistical significance testing."""
     try:
         logger.info(f"Performing correlation analysis on: {file_path}")
-        return get_correlation_analysis(file_path, method, columns)
+        return cast(
+            CorrelationAnalysisResult,
+            get_correlation_analysis(file_path, method, columns),
+        )
     except Exception as e:
         logger.error(f"Correlation analysis error: {e}")
         raise ToolError(f"Correlation analysis error: {e}") from e
@@ -219,7 +743,7 @@ async def correlation_analysis_tool(
 
 @mcp.tool(
     name="hypothesis_testing",
-    title="test(hypothesis)",
+    title="Hypothesis Test",
     description="Run statistical hypothesis tests (t-test, chi-square, ANOVA, normality, Mann-Whitney) with p-values and effect sizes.",
     annotations={
         "readOnlyHint": True,
@@ -246,11 +770,14 @@ async def hypothesis_testing_tool(
     alpha: Annotated[
         float, Field(description="Significance level (e.g. 0.05, 0.01)")
     ] = 0.05,
-) -> dict:
+) -> HypothesisTestingResult:
     """Perform statistical hypothesis testing with effect size and confidence intervals."""
     try:
         logger.info(f"Performing hypothesis testing on: {file_path}")
-        return hypothesis_testing(file_path, test_type, column1, column2, alpha)
+        return cast(
+            HypothesisTestingResult,
+            hypothesis_testing(file_path, test_type, column1, column2, alpha),
+        )
     except Exception as e:
         logger.error(f"Hypothesis testing error: {e}")
         raise ToolError(f"Hypothesis testing error: {e}") from e
@@ -263,7 +790,7 @@ async def hypothesis_testing_tool(
 
 @mcp.tool(
     name="handle_missing_data",
-    title="fix(missing)",
+    title="Fix Missing Data",
     description="Detect, impute, or remove missing values using strategies like mean/median/mode fill, forward/backward fill, or interpolation.",
     annotations={
         "readOnlyHint": True,
@@ -286,11 +813,14 @@ async def handle_missing_data_tool(
     columns: Annotated[
         Optional[List[str]], Field(description="Columns to process; None processes all")
     ] = None,
-) -> dict:
+) -> HandleMissingDataResult:
     """Handle missing data with comprehensive strategies and statistical methods."""
     try:
         logger.info(f"Handling missing data in: {file_path}")
-        return handle_missing_data(file_path, strategy, method, columns)
+        return cast(
+            HandleMissingDataResult,
+            handle_missing_data(file_path, strategy, method, columns),
+        )
     except Exception as e:
         logger.error(f"Missing data handling error: {e}")
         raise ToolError(f"Missing data handling error: {e}") from e
@@ -298,7 +828,7 @@ async def handle_missing_data_tool(
 
 @mcp.tool(
     name="clean_data",
-    title="clean(data)",
+    title="Clean Data",
     description="Remove duplicates, detect outliers via IQR/Z-score, and optimize data types in a single pass.",
     annotations={
         "readOnlyHint": True,
@@ -318,11 +848,14 @@ async def clean_data_tool(
     convert_types: Annotated[
         bool, Field(description="Automatically optimize data types")
     ] = False,
-) -> dict:
+) -> CleanDataResult:
     """Perform comprehensive data cleaning with advanced quality improvement techniques."""
     try:
         logger.info(f"Cleaning data in: {file_path}")
-        return clean_data(file_path, remove_duplicates, detect_outliers, convert_types)
+        return cast(
+            CleanDataResult,
+            clean_data(file_path, remove_duplicates, detect_outliers, convert_types),
+        )
     except Exception as e:
         logger.error(f"Data cleaning error: {e}")
         raise ToolError(f"Data cleaning error: {e}") from e
@@ -335,7 +868,7 @@ async def clean_data_tool(
 
 @mcp.tool(
     name="groupby_operations",
-    title="group(data)",
+    title="Group Data",
     description="Group data by columns and apply aggregations (sum, mean, count, min, max, std, median) with optional pre-filter.",
     annotations={
         "readOnlyHint": True,
@@ -357,11 +890,14 @@ async def groupby_operations_tool(
         Optional[str],
         Field(description="Optional pandas query string to filter before grouping"),
     ] = None,
-) -> dict:
+) -> GroupByOperationsResult:
     """Perform sophisticated groupby operations with comprehensive aggregation options."""
     try:
         logger.info(f"Performing groupby operations on: {file_path}")
-        return groupby_operations(file_path, group_by, operations, filter_condition)
+        return cast(
+            GroupByOperationsResult,
+            groupby_operations(file_path, group_by, operations, filter_condition),
+        )
     except Exception as e:
         logger.error(f"Groupby operations error: {e}")
         raise ToolError(f"Groupby operations error: {e}") from e
@@ -369,7 +905,7 @@ async def groupby_operations_tool(
 
 @mcp.tool(
     name="merge_datasets",
-    title="merge(data)",
+    title="Merge Datasets",
     description="Join two datasets using inner, outer, left, or right joins on specified key columns.",
     annotations={
         "readOnlyHint": True,
@@ -393,11 +929,14 @@ async def merge_datasets_tool(
     on: Annotated[
         Optional[str], Field(description="Common join column (if same name in both)")
     ] = None,
-) -> dict:
+) -> MergeDatasetsResult:
     """Merge and join datasets with comprehensive integration capabilities."""
     try:
         logger.info(f"Merging datasets: {left_file} and {right_file}")
-        return merge_datasets(left_file, right_file, join_type, left_on, right_on, on)
+        return cast(
+            MergeDatasetsResult,
+            merge_datasets(left_file, right_file, join_type, left_on, right_on, on),
+        )
     except Exception as e:
         logger.error(f"Dataset merge error: {e}")
         raise ToolError(f"Dataset merge error: {e}") from e
@@ -405,7 +944,7 @@ async def merge_datasets_tool(
 
 @mcp.tool(
     name="pivot_table",
-    title="pivot(table)",
+    title="Pivot Table",
     description="Create pivot tables with configurable row index, column headers, value columns, and aggregation function.",
     annotations={
         "readOnlyHint": True,
@@ -428,11 +967,14 @@ async def pivot_table_tool(
         str,
         Field(description="Aggregation function: mean, sum, count, min, max, std, var"),
     ] = "mean",
-) -> dict:
+) -> PivotTableResult:
     """Create sophisticated pivot tables with comprehensive aggregation options."""
     try:
         logger.info(f"Creating pivot table for: {file_path}")
-        return create_pivot_table(file_path, index, columns, values, aggfunc)
+        return cast(
+            PivotTableResult,
+            create_pivot_table(file_path, index, columns, values, aggfunc),
+        )
     except Exception as e:
         logger.error(f"Pivot table error: {e}")
         raise ToolError(f"Pivot table error: {e}") from e
@@ -445,7 +987,7 @@ async def pivot_table_tool(
 
 @mcp.tool(
     name="time_series_operations",
-    title="transform(series)",
+    title="Transform Series",
     description="Resample, compute rolling statistics, create lag features, or difference a time series.",
     annotations={
         "readOnlyHint": True,
@@ -469,12 +1011,15 @@ async def time_series_operations_tool(
     frequency: Annotated[
         Optional[str], Field(description="Resampling frequency: D, W, M, Q, Y")
     ] = None,
-) -> dict:
+) -> TimeSeriesOperationsResult:
     """Perform comprehensive time series operations with advanced temporal analysis."""
     try:
         logger.info(f"Performing time series operations on: {file_path}")
-        return time_series_operations(
-            file_path, date_column, operation, window_size, frequency
+        return cast(
+            TimeSeriesOperationsResult,
+            time_series_operations(
+                file_path, date_column, operation, window_size, frequency
+            ),
         )
     except Exception as e:
         logger.error(f"Time series operations error: {e}")
@@ -488,7 +1033,7 @@ async def time_series_operations_tool(
 
 @mcp.tool(
     name="validate_data",
-    title="validate(data)",
+    title="Validate Data",
     description="Validate columns against rules for min/max range, data type, nullability, uniqueness, and regex patterns.",
     annotations={
         "readOnlyHint": True,
@@ -505,11 +1050,11 @@ async def validate_data_tool(
             description="Validation rules: {column: {rule_type: value}}. Rules: min_value, max_value, dtype, allow_null, unique, pattern"
         ),
     ],
-) -> dict:
+) -> ValidateDataResult:
     """Perform comprehensive data validation with advanced constraint checking."""
     try:
         logger.info(f"Validating data in: {file_path}")
-        return validate_data(file_path, validation_rules)
+        return cast(ValidateDataResult, validate_data(file_path, validation_rules))
     except Exception as e:
         logger.error(f"Data validation error: {e}")
         raise ToolError(f"Data validation error: {e}") from e
@@ -522,7 +1067,7 @@ async def validate_data_tool(
 
 @mcp.tool(
     name="filter_data",
-    title="filter(data)",
+    title="Filter Data",
     description="Filter rows using comparison, membership, pattern-matching, and null-check operators across multiple columns.",
     annotations={
         "readOnlyHint": True,
@@ -543,11 +1088,13 @@ async def filter_data_tool(
         Optional[str],
         Field(description="Path to save filtered data; None returns in memory"),
     ] = None,
-) -> dict:
+) -> FilterDataResult:
     """Perform advanced data filtering with boolean indexing and conditional expressions."""
     try:
         logger.info(f"Filtering data in: {file_path}")
-        return filter_data(file_path, filter_conditions, output_file)
+        return cast(
+            FilterDataResult, filter_data(file_path, filter_conditions, output_file)
+        )
     except Exception as e:
         logger.error(f"Data filtering error: {e}")
         raise ToolError(f"Data filtering error: {e}") from e
@@ -560,7 +1107,7 @@ async def filter_data_tool(
 
 @mcp.tool(
     name="optimize_memory",
-    title="optimize(memory)",
+    title="Optimize Memory",
     description="Analyze and reduce DataFrame memory usage through automatic dtype optimization and chunked-processing recommendations.",
     annotations={
         "readOnlyHint": True,
@@ -579,11 +1126,14 @@ async def optimize_memory_tool(
         Optional[int],
         Field(description="Chunk size for processing large files; None for automatic"),
     ] = None,
-) -> dict:
+) -> OptimizeMemoryResult:
     """Perform advanced memory optimization for large datasets."""
     try:
         logger.info(f"Optimizing memory usage for: {file_path}")
-        return optimize_memory_usage(file_path, optimize_dtypes, chunk_size)
+        return cast(
+            OptimizeMemoryResult,
+            optimize_memory_usage(file_path, optimize_dtypes, chunk_size),
+        )
     except Exception as e:
         logger.error(f"Memory optimization error: {e}")
         raise ToolError(f"Memory optimization error: {e}") from e
@@ -596,7 +1146,7 @@ async def optimize_memory_tool(
 
 @mcp.tool(
     name="profile_data",
-    title="profile(data)",
+    title="Profile Data",
     description="Generate a full dataset profile: shape, types, missing values, distributions, quality checks, and optional correlations.",
     annotations={
         "readOnlyHint": True,
@@ -614,11 +1164,14 @@ async def profile_data_tool(
         Optional[int],
         Field(description="Rows to sample for large datasets; None uses full dataset"),
     ] = None,
-) -> dict:
+) -> ProfileDataResult:
     """Perform comprehensive data profiling with statistical analysis and quality assessment."""
     try:
         logger.info(f"Profiling data in: {file_path}")
-        return profile_data(file_path, include_correlations, sample_size)
+        return cast(
+            ProfileDataResult,
+            profile_data(file_path, include_correlations, sample_size),
+        )
     except Exception as e:
         logger.error(f"Data profiling error: {e}")
         raise ToolError(f"Data profiling error: {e}") from e
@@ -626,7 +1179,7 @@ async def profile_data_tool(
 
 @mcp.tool(
     name="profile_csv",
-    title="profile(csv)",
+    title="Profile CSV",
     description="Quickly profile a CSV file: row/column counts, per-column dtype, null counts, and min/max/mean for numeric columns.",
     annotations={
         "readOnlyHint": True,
@@ -647,7 +1200,7 @@ async def profile_csv_tool(
             description="Maximum rows to retain for statistics (default 5000, capped at 250000)"
         ),
     ] = None,
-) -> dict:
+) -> ProfileCsvResult:
     """Generate a fast, dependency-light profile of a CSV file."""
     try:
         logger.info(f"Profiling CSV file: {data_path}")
@@ -656,7 +1209,7 @@ async def profile_csv_tool(
             raise ToolError(
                 f"CSV profiling error: {result.get('error', 'unknown error')}"
             )
-        return result
+        return cast(ProfileCsvResult, result)
     except ToolError:
         raise
     except Exception as e:

--- a/clio-kit-mcp-servers/pandas/tests/test_output_schemas.py
+++ b/clio-kit-mcp-servers/pandas/tests/test_output_schemas.py
@@ -1,0 +1,207 @@
+"""Verify pandas tools declare real MCP output semantics (2026-07-28 protocol).
+
+Every tool's registration must advertise a real, field-level ``outputSchema``
+— not the useless generic ``{"type": "object", "additionalProperties": true}``
+FastMCP derives from a bare ``-> dict`` return annotation. This drives the
+server through an in-memory ``fastmcp.Client``, so it exercises exactly what
+a real MCP client sees on the wire (mirrors plot_mcp's
+``test_tools_list_advertises_real_output_schemas``).
+
+Uses ``asyncio.run`` rather than ``@pytest.mark.asyncio``: this server's dev
+dependency group does not carry a pytest asyncio plugin (unlike some sibling
+servers), and pytest silently skips async def tests it cannot run rather than
+failing loudly, so a marker-based test could pass by doing nothing. Driving
+the event loop explicitly keeps the assertion honest without adding a new dev
+dependency just for this test.
+"""
+
+import asyncio
+
+from fastmcp import Client
+
+from pandas_mcp.server import mcp
+
+# All 16 pandas tools. Every one of them returns a "success" dict (traced
+# from the real implementation code, not docstrings) -- none of them use a
+# "status" field the way the plot server's tools do.
+ALL_TOOL_NAMES = {
+    "load_data",
+    "save_data",
+    "statistical_summary",
+    "correlation_analysis",
+    "hypothesis_testing",
+    "handle_missing_data",
+    "clean_data",
+    "groupby_operations",
+    "merge_datasets",
+    "pivot_table",
+    "time_series_operations",
+    "validate_data",
+    "filter_data",
+    "optimize_memory",
+    "profile_data",
+    "profile_csv",
+}
+
+# Fields grounded from the actual `return {...}` statements in each tool's
+# implementation function (see src/pandas_mcp/implementation/*.py). Every
+# tool's outputSchema must advertise at least these always-present fields.
+EXPECTED_TOP_LEVEL_FIELDS = {
+    "load_data": {"success", "file_path", "file_format", "data", "total_rows", "info"},
+    "save_data": {
+        "success",
+        "file_path",
+        "file_format",
+        "file_size_bytes",
+        "file_size_mb",
+        "rows_saved",
+        "columns_saved",
+    },
+    "statistical_summary": {
+        "success",
+        "file_path",
+        "shape",
+        "basic_statistics",
+        "additional_statistics",
+        "categorical_statistics",
+        "missing_data",
+    },
+    "correlation_analysis": {
+        "success",
+        "file_path",
+        "method",
+        "correlation_matrix",
+        "high_correlations",
+        "analyzed_columns",
+    },
+    "hypothesis_testing": {"success", "file_path", "test_info", "results"},
+    "handle_missing_data": {
+        "success",
+        "file_path",
+        "original_shape",
+        "missing_data_info",
+    },
+    "clean_data": {"success", "file_path", "output_file", "cleaning_results"},
+    "groupby_operations": {
+        "success",
+        "file_path",
+        "output_file",
+        "group_info",
+        "results",
+    },
+    "merge_datasets": {
+        "success",
+        "left_file",
+        "right_file",
+        "output_file",
+        "merge_stats",
+        "merged_data",
+    },
+    "pivot_table": {"success", "file_path", "output_file", "pivot_info", "pivot_table"},
+    "time_series_operations": {
+        "success",
+        "file_path",
+        "output_file",
+        "operation_info",
+        "results",
+    },
+    "validate_data": {
+        "success",
+        "file_path",
+        "validation_summary",
+        "validation_results",
+    },
+    "filter_data": {
+        "success",
+        "file_path",
+        "output_file",
+        "filter_stats",
+        "filtered_data",
+    },
+    "optimize_memory": {
+        "success",
+        "file_path",
+        "output_file",
+        "system_memory",
+        "optimization_results",
+        "column_memory_usage",
+        "optimization_log",
+        "recommendations",
+    },
+    "profile_data": {
+        "success",
+        "file_path",
+        "basic_info",
+        "summary",
+        "missing_data",
+        "column_analysis",
+        "quality_checks",
+    },
+    "profile_csv": {
+        "success",
+        "file_path",
+        "size_bytes",
+        "columns",
+        "column_count",
+        "row_count",
+        "rows_profiled",
+        "dtypes",
+        "null_counts",
+        "numeric_summary",
+        "sample_rows",
+    },
+}
+
+
+def _list_tools():
+    async def _run():
+        async with Client(mcp) as client:
+            return await client.list_tools()
+
+    return asyncio.run(_run())
+
+
+def test_tools_list_advertises_real_output_schemas() -> None:
+    """tools/list must show a field-level outputSchema for every pandas tool."""
+    tools = {tool.name: tool for tool in _list_tools()}
+
+    missing = ALL_TOOL_NAMES - set(tools)
+    assert not missing, f"tools missing from tools/list: {missing}"
+
+    for name in ALL_TOOL_NAMES:
+        schema = tools[name].output_schema
+        assert schema is not None, f"{name} has no outputSchema"
+        assert schema.get("type") == "object", f"{name} outputSchema is not an object"
+        properties = schema.get("properties")
+        assert properties, f"{name} outputSchema has no real field properties: {schema}"
+
+        # Every pandas tool reports "success" on its structured result.
+        assert "success" in properties, f"{name} outputSchema missing 'success' field"
+
+
+def test_output_schemas_expose_the_known_fields() -> None:
+    """Each tool's outputSchema must expose the fields grounded from its
+    implementation's actual success-path return statement, not a subset that
+    happens to satisfy a generic {"type": "object"} check."""
+    tools = {tool.name: tool for tool in _list_tools()}
+
+    for name, expected_fields in EXPECTED_TOP_LEVEL_FIELDS.items():
+        schema = tools[name].output_schema
+        assert schema is not None, f"{name} has no outputSchema"
+        properties = set(schema.get("properties", {}))
+        missing = expected_fields - properties
+        assert not missing, f"{name} outputSchema missing known fields: {missing}"
+
+
+def test_no_tool_uses_the_generic_bare_dict_schema() -> None:
+    """Guard against regressing back to FastMCP's useless generic schema for
+    a bare `-> dict` annotation: {"type": "object", "additionalProperties": True}
+    with no real `properties`."""
+    tools = {tool.name: tool for tool in _list_tools()}
+
+    generic = {
+        name
+        for name in ALL_TOOL_NAMES
+        if not (tools[name].output_schema or {}).get("properties")
+    }
+    assert not generic, f"tools still advertising a generic bare-dict schema: {generic}"

--- a/clio-kit-mcp-servers/pandas/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/pandas/tests/test_tool_titles.py
@@ -1,8 +1,10 @@
 """Every tool the pandas MCP server registers must carry a compact display title.
 
 The consuming UI reads `Tool.title` (falling back to `annotations.title`, then
-`name`) to render a small-title register — e.g. `filter(data)`. This asserts
-every tool advertises one, and that it fits the compact register's length budget.
+`name`) to render a compact register of plain Title Case names — e.g. `Filter
+Data`. Parens are injected by the UI around the call's arguments, not part of
+the title. This asserts every tool advertises one, and that it fits the
+compact register's length budget.
 
 Uses `asyncio.run` rather than `@pytest.mark.asyncio` / anyio markers: this
 server's dev dependency group does not carry a pytest asyncio plugin (unlike
@@ -41,3 +43,11 @@ def test_titles_fit_the_compact_register() -> None:
         t.name: t.title for t in tools if t.title and len(t.title) > MAX_TITLE_LENGTH
     }
     assert not too_long, f"titles exceed {MAX_TITLE_LENGTH} chars: {too_long}"
+
+
+def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    tools = _list_tools()
+    with_parens = [t.name for t in tools if t.title and "(" in t.title]
+    assert not with_parens, f"tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/pandas/uv.lock
+++ b/clio-kit-mcp-servers/pandas/uv.lock
@@ -790,15 +790,15 @@ wheels = [
 
 [[package]]
 name = "h2"
-version = "4.3.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
 ]
 
 [[package]]
@@ -854,15 +854,6 @@ wheels = [
 [package.optional-dependencies]
 http2 = [
     { name = "h2" },
-]
-
-[[package]]
-name = "httpx-sse"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/src/parallel_sort_mcp/server.py
+++ b/clio-kit-mcp-servers/parallel-sort/src/parallel_sort_mcp/server.py
@@ -56,7 +56,7 @@ def sort_large_file(file_path: str) -> list[Message]:
 
 @mcp.tool(
     name="sort_log_by_timestamp",
-    title="sort(timestamp)",
+    title="Sort By Timestamp",
     description="Sort log file lines by timestamps in YYYY-MM-DD HH:MM:SS format.",
     annotations={
         "readOnlyHint": False,
@@ -84,7 +84,7 @@ async def sort_log_tool(
 
 @mcp.tool(
     name="parallel_sort_large_file",
-    title="sort(parallel)",
+    title="Parallel Sort",
     description="Sort large log files using parallel processing with chunked approach.",
     annotations={
         "readOnlyHint": False,
@@ -118,7 +118,7 @@ async def parallel_sort_tool(
 
 @mcp.tool(
     name="analyze_log_statistics",
-    title="analyze(stats)",
+    title="Analyze Statistics",
     description="Generate statistics for log files including temporal patterns and log levels.",
     annotations={
         "readOnlyHint": True,
@@ -143,7 +143,7 @@ async def analyze_statistics_tool(log_file: str, include_patterns: bool = True) 
 
 @mcp.tool(
     name="detect_log_patterns",
-    title="detect(patterns)",
+    title="Detect Patterns",
     description="Detect patterns in log files including anomalies and error clusters.",
     annotations={
         "readOnlyHint": True,
@@ -175,7 +175,7 @@ async def detect_patterns_tool(
 
 @mcp.tool(
     name="filter_logs",
-    title="filter(logs)",
+    title="Filter Logs",
     description="Filter log entries based on multiple conditions with logical operations.",
     annotations={
         "readOnlyHint": False,
@@ -209,7 +209,7 @@ async def filter_logs_tool(
 
 @mcp.tool(
     name="filter_by_time_range",
-    title="filter(time)",
+    title="Filter Time Range",
     description="Filter log entries by time range using start and end timestamps.",
     annotations={
         "readOnlyHint": False,
@@ -240,7 +240,7 @@ async def filter_time_range_tool(
 
 @mcp.tool(
     name="filter_by_log_level",
-    title="filter(level)",
+    title="Filter By Level",
     description="Filter log entries by log level (ERROR, WARN, INFO, DEBUG, etc.).",
     annotations={
         "readOnlyHint": False,
@@ -268,7 +268,7 @@ async def filter_level_tool(
 
 @mcp.tool(
     name="filter_by_keyword",
-    title="filter(keyword)",
+    title="Filter By Keyword",
     description="Filter log entries by keywords with support for multiple keywords and logical operations.",
     annotations={
         "readOnlyHint": False,
@@ -304,7 +304,7 @@ async def filter_keyword_tool(
 
 @mcp.tool(
     name="apply_filter_preset",
-    title="apply(preset)",
+    title="Apply Filter Preset",
     description="Apply predefined filter presets like 'errors_only' or 'connection_issues'.",
     annotations={
         "readOnlyHint": False,
@@ -332,7 +332,7 @@ async def filter_preset_tool(
 
 @mcp.tool(
     name="export_to_json",
-    title="export(json)",
+    title="Export JSON",
     description="Export log processing results to JSON format.",
     annotations={
         "readOnlyHint": False,
@@ -357,7 +357,7 @@ async def export_json_tool(data: dict, include_metadata: bool = True) -> dict:
 
 @mcp.tool(
     name="export_to_csv",
-    title="export(csv)",
+    title="Export CSV",
     description="Export log entries to CSV format with structured columns.",
     annotations={
         "readOnlyHint": False,
@@ -382,7 +382,7 @@ async def export_csv_tool(data: dict, include_headers: bool = True) -> dict:
 
 @mcp.tool(
     name="export_to_text",
-    title="export(text)",
+    title="Export Text",
     description="Export log entries to plain text format.",
     annotations={
         "readOnlyHint": False,
@@ -407,7 +407,7 @@ async def export_text_tool(data: dict, include_summary: bool = True) -> dict:
 
 @mcp.tool(
     name="generate_summary_report",
-    title="report(summary)",
+    title="Summary Report",
     description="Generate a summary report of log processing results with statistics.",
     annotations={
         "readOnlyHint": True,

--- a/clio-kit-mcp-servers/parallel-sort/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/parallel-sort/tests/test_tool_titles.py
@@ -41,3 +41,14 @@ async def test_expected_tool_count_has_titles() -> None:
 
     titled = {t.name: t.title for t in tools if t.title}
     assert len(titled) == len(tools) == 13
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/src/paraview_mcp/server.py
+++ b/clio-kit-mcp-servers/paraview/src/paraview_mcp/server.py
@@ -106,7 +106,7 @@ def get_pv_manager() -> "VisualizationEngine":
 
 @mcp.tool(
     name="load_scientific_data",
-    title="load(data)",
+    title="Load Data File",
     description="Load scientific datasets (VTK, EXODUS, CSV, RAW, BP5) into ParaView with automatic format detection.",
     annotations={
         "readOnlyHint": False,
@@ -162,7 +162,7 @@ async def read_datafile_tool(file_path: str) -> str:
 
 
 @mcp.tool(
-    title="save(stl)",
+    title="Save STL",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -187,7 +187,7 @@ def save_contour_as_stl(stl_filename: str = "contour.stl") -> str:
 
 @mcp.tool(
     name="create_geometric_shape",
-    title="create(shape)",
+    title="Create Shape",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -213,7 +213,7 @@ def create_source(source_type: str) -> str:
 
 @mcp.tool(
     name="generate_isosurface",
-    title="create(isosurface)",
+    title="Create Isosurface",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -242,7 +242,7 @@ def create_isosurface(value: float, field: Optional[str] = None) -> str:
 
 @mcp.tool(
     name="create_data_slice",
-    title="create(slice)",
+    title="Create Slice",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -279,7 +279,7 @@ def create_slice(
 
 @mcp.tool(
     name="configure_volume_display",
-    title="toggle(volume)",
+    title="Toggle Volume",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -304,7 +304,7 @@ def toggle_volume_rendering(enable: bool = True) -> str:
 
 
 @mcp.tool(
-    title="toggle(visibility)",
+    title="Toggle Visibility",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -329,7 +329,7 @@ def toggle_visibility(enable: bool = True) -> str:
 
 
 @mcp.tool(
-    title="set(source)",
+    title="Set Active Source",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -353,7 +353,7 @@ def set_active_source(name: str) -> str:
 
 
 @mcp.tool(
-    title="list(sources)",
+    title="List Sources",
     annotations={
         "readOnlyHint": True,
         "destructiveHint": False,
@@ -405,7 +405,7 @@ def get_active_source_names_by_type(source_type: Optional[str] = None) -> str:
 
 
 @mcp.tool(
-    title="edit(opacity)",
+    title="Edit Opacity",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -453,7 +453,7 @@ def edit_volume_opacity(field_name: str, opacity_points: list[dict[str, float]])
 
 
 @mcp.tool(
-    title="set(colormap)",
+    title="Set Color Map",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -484,7 +484,7 @@ def set_color_map(field_name: str, color_points: list[dict]) -> str:
 
 @mcp.tool(
     name="apply_field_coloring",
-    title="color(field)",
+    title="Color By Field",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -509,7 +509,7 @@ def color_by(field: str, component: int = -1) -> str:
 
 
 @mcp.tool(
-    title="compute(area)",
+    title="Compute Surface Area",
     annotations={
         "readOnlyHint": True,
         "destructiveHint": False,
@@ -530,7 +530,7 @@ def compute_surface_area() -> str:
 
 
 @mcp.tool(
-    title="set(preset)",
+    title="Set Color Preset",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -554,7 +554,7 @@ def set_color_map_preset(preset_name: str = "Cool to Warm") -> str:
 
 
 @mcp.tool(
-    title="set(representation)",
+    title="Set Representation",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -578,7 +578,7 @@ def set_representation_type(rep_type: str) -> str:
 
 
 @mcp.tool(
-    title="get(pipeline)",
+    title="Get Pipeline",
     annotations={
         "readOnlyHint": True,
         "destructiveHint": False,
@@ -599,7 +599,7 @@ def get_pipeline() -> str:
 
 
 @mcp.tool(
-    title="list(arrays)",
+    title="List Arrays",
     annotations={
         "readOnlyHint": True,
         "destructiveHint": False,
@@ -620,7 +620,7 @@ def get_available_arrays() -> str:
 
 
 @mcp.tool(
-    title="compute(histogram)",
+    title="Compute Histogram",
     annotations={
         "readOnlyHint": True,
         "destructiveHint": False,
@@ -673,7 +673,7 @@ def get_histogram(
 
 @mcp.tool(
     name="generate_flow_streamlines",
-    title="create(streamlines)",
+    title="Create Streamlines",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -720,7 +720,7 @@ def create_streamline(
 
 @mcp.tool(
     name="take_viewport_screenshot",
-    title="capture(screenshot)",
+    title="Capture Screenshot",
     description="Capture a screenshot of the current ParaView viewport and save it as a timestamped PNG.",
     annotations={
         "readOnlyHint": True,
@@ -756,7 +756,7 @@ async def get_screenshot_tool() -> str:
 
 @mcp.tool(
     name="show_screenshot_preview",
-    title="preview(screenshot)",
+    title="Preview Screenshot",
     description="Capture a screenshot with inline preview using temporary files.",
     annotations={
         "readOnlyHint": True,
@@ -822,7 +822,7 @@ async def show_screenshot_preview() -> str:
 
 
 @mcp.tool(
-    title="rotate(camera)",
+    title="Rotate Camera",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -847,7 +847,7 @@ def rotate_camera(azimuth: float = 30.0, elevation: float = 0.0) -> str:
 
 
 @mcp.tool(
-    title="reset(camera)",
+    title="Reset Camera",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -885,7 +885,7 @@ def reset_camera() -> str:
 
 
 @mcp.tool(
-    title="plot(line)",
+    title="Plot Over Line",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -917,7 +917,7 @@ def plot_over_line(
 
 
 @mcp.tool(
-    title="warp(vector)",
+    title="Warp By Vector",
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
@@ -946,7 +946,7 @@ def warp_by_vector(
 
 
 @mcp.tool(
-    title="list(commands)",
+    title="List Commands",
     annotations={
         "readOnlyHint": True,
         "destructiveHint": False,

--- a/clio-kit-mcp-servers/paraview/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/paraview/tests/test_tool_titles.py
@@ -53,3 +53,17 @@ async def test_expected_tool_count_has_titles() -> None:
 
     titled = {t.name: t.title for t in tools if t.title}
     assert len(titled) == len(tools) == 26
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    if mcp is None:
+        pytest.skip(f"ParaView MCP server not importable: {IMPORT_ERROR}")
+
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/src/parquet_mcp/server.py
+++ b/clio-kit-mcp-servers/parquet/src/parquet_mcp/server.py
@@ -35,7 +35,7 @@ mcp = FastMCP(
 
 
 @mcp.tool(
-    title="summarize(parquet)",
+    title="Summarize",
     description="Return Parquet schema, row count, and file size.",
     annotations={
         "readOnlyHint": True,
@@ -57,7 +57,7 @@ async def summarize_tool(file_path: str) -> str:
 
 
 @mcp.tool(
-    title="read(slice)",
+    title="Read Slice",
     description="Read a row slice from a Parquet file with optional column projection and filtering.",
     annotations={
         "readOnlyHint": True,
@@ -92,7 +92,7 @@ async def read_slice_tool(
 
 
 @mcp.tool(
-    title="preview(column)",
+    title="Preview Column",
     description="Preview values from a specific column with pagination.",
     annotations={
         "readOnlyHint": True,
@@ -121,7 +121,7 @@ async def get_column_preview_tool(
 
 
 @mcp.tool(
-    title="aggregate(column)",
+    title="Aggregate Column",
     description="Compute aggregate statistics (min, max, mean, etc.) on a Parquet column.",
     annotations={
         "readOnlyHint": True,

--- a/clio-kit-mcp-servers/parquet/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/parquet/tests/test_tool_titles.py
@@ -28,3 +28,14 @@ async def test_every_tool_has_a_short_title() -> None:
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/src/plot_mcp/implementation/plot_capabilities.py
+++ b/clio-kit-mcp-servers/plot/src/plot_mcp/implementation/plot_capabilities.py
@@ -2,11 +2,22 @@
 Plot capabilities implementation for data visualization.
 """
 
+import io
 import json
 import math
 import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List
+
+import matplotlib
+
+# This is an unattended, headless MCP server: it must never depend on a GUI
+# toolkit (Tk, Qt, ...) being installed, and must never try to open a window.
+# Force the non-interactive Agg backend before pyplot picks one on its own —
+# otherwise backend selection silently depends on import order and on
+# whatever GUI toolkits happen to be present, and plotting breaks wherever
+# they are not (see the 2.7.1 output-content regression test that caught this).
+matplotlib.use("Agg")
 
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
@@ -14,8 +25,35 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 import logging
+from PIL import Image as PILImage
 
 logger = logging.getLogger(__name__)
+
+PREVIEW_MAX_WIDTH = 800
+
+
+def build_preview_png(output_path: str, max_width: int = PREVIEW_MAX_WIDTH) -> bytes:
+    """Downscale the full-resolution plot on disk into a bounded PNG preview.
+
+    The full-resolution file (saved at ``dpi=300``, often multiple megabytes)
+    stays on disk at ``output_path``; this returns a small, wire-safe preview
+    fit for embedding directly in an MCP ``ImageContent`` block.
+
+    Args:
+        output_path: Path to the full-resolution PNG already written to disk.
+        max_width: Maximum preview width in pixels; height scales to match.
+
+    Returns:
+        PNG-encoded bytes no wider than ``max_width`` pixels.
+    """
+    with PILImage.open(output_path) as full_image:
+        image = full_image.convert("RGB")
+        if image.width > max_width:
+            new_height = round(image.height * (max_width / image.width))
+            image = image.resize((max_width, new_height), PILImage.Resampling.LANCZOS)
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG", optimize=True)
+        return buffer.getvalue()
 
 
 def load_data(file_path: str) -> pd.DataFrame:

--- a/clio-kit-mcp-servers/plot/src/plot_mcp/server.py
+++ b/clio-kit-mcp-servers/plot/src/plot_mcp/server.py
@@ -6,13 +6,15 @@ pandas and matplotlib.
 """
 
 import os
-from typing import Annotated
+from typing import Annotated, Any, Literal, TypedDict, cast
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.prompts import Message
+from fastmcp.tools import ToolResult
+from fastmcp.utilities.types import Image
 from dotenv import load_dotenv
-from pydantic import Field
+from pydantic import Field, TypeAdapter
 import logging
 from .implementation.plot_capabilities import (
     create_line_plot,
@@ -22,7 +24,129 @@ from .implementation.plot_capabilities import (
     create_heatmap,
     create_timeseries_plot,
     get_data_info,
+    build_preview_png,
 )
+
+
+# --- Structured result shapes (drive real MCP outputSchema declarations) ----
+
+
+class LinePlotResult(TypedDict):
+    """Structured result for a successful line plot."""
+
+    status: Literal["success"]
+    plot_type: Literal["line"]
+    output_path: str
+    x_column: str
+    y_column: str
+    title: str
+    data_points: int
+
+
+class BarPlotResult(TypedDict):
+    """Structured result for a successful bar plot."""
+
+    status: Literal["success"]
+    plot_type: Literal["bar"]
+    output_path: str
+    x_column: str
+    y_column: str
+    title: str
+    data_points: int
+    aggregated: bool
+
+
+class ScatterPlotResult(TypedDict):
+    """Structured result for a successful scatter plot."""
+
+    status: Literal["success"]
+    plot_type: Literal["scatter"]
+    output_path: str
+    x_column: str
+    y_column: str
+    title: str
+    data_points: int
+
+
+class HistogramResult(TypedDict):
+    """Structured result for a successful histogram."""
+
+    status: Literal["success"]
+    plot_type: Literal["histogram"]
+    output_path: str
+    column: str
+    bins: int
+    title: str
+    data_points: int
+
+
+class HeatmapResult(TypedDict):
+    """Structured result for a successful correlation heatmap."""
+
+    status: Literal["success"]
+    plot_type: Literal["heatmap"]
+    output_path: str
+    title: str
+    data_points: int
+    numeric_columns: list[str]
+
+
+class TimeseriesXAxis(TypedDict):
+    """Inferred x-axis metadata for a time-series plot."""
+
+    kind: Literal[
+        "epoch_milliseconds",
+        "epoch_seconds",
+        "datetime",
+        "numeric",
+        "categorical",
+        "row_index",
+    ]
+    label: str
+    parse_success_ratio: float
+
+
+class TimeseriesPlotResult(TypedDict):
+    """Structured result for a successful multi-series time-series plot."""
+
+    status: Literal["success"]
+    plot_type: Literal["timeseries"]
+    output_path: str
+    x_column: str
+    x_axis: TimeseriesXAxis
+    y_columns: list[str]
+    title: str
+    data_points: int
+
+
+class DataInfoResult(TypedDict):
+    """Structured result describing a CSV/Excel file's schema and contents."""
+
+    status: Literal["success"]
+    file_path: str
+    shape: tuple[int, int]
+    columns: list[str]
+    dtypes: dict[str, str]
+    null_counts: dict[str, int]
+    memory_usage: int
+    head: dict[str, Any]
+
+
+def _plot_tool_result(structured: dict[str, Any]) -> ToolResult:
+    """Wrap a plot capability's structured result with a bounded PNG preview.
+
+    Every image-producing plot tool returns both a rendered MCP
+    ``ImageContent`` block (a downscaled preview, bounded to ~800px wide so
+    the wire payload stays small) and the unmodified structured dict —
+    ``output_path`` in that dict still points at the full-resolution file on
+    disk; nothing about the saved file changes.
+    """
+    preview_bytes = build_preview_png(structured["output_path"])
+    return ToolResult(
+        content=[Image(data=preview_bytes, format="png")],
+        structured_content=structured,
+    )
+
 
 # Configure logging
 logging.basicConfig(
@@ -41,14 +165,15 @@ mcp: FastMCP = FastMCP(
         "Generate line plots, bar charts, scatter plots, histograms, heatmaps, and "
         "multi-series time-series line charts from data. Use plot_timeseries to plot "
         "one or more y columns against an auto-detected time, numeric, or categorical "
-        "x axis. All plots are saved to files."
+        "x axis. Every plot tool saves the full-resolution image to output_path and "
+        "also returns a bounded PNG preview inline in the response for immediate viewing."
     ),
 )
 
 
 @mcp.tool(
     name="line_plot",
-    title="plot(line)",
+    title="Line Plot",
     description="Create a line plot from CSV or Excel data with customizable styling.",
     annotations={
         "readOnlyHint": False,
@@ -56,6 +181,7 @@ mcp: FastMCP = FastMCP(
         "idempotentHint": True,
     },
     tags={"plot", "line-chart", "visualization"},
+    output_schema=TypeAdapter(LinePlotResult).json_schema(mode="serialization"),
 )
 async def line_plot_tool(
     file_path: str,
@@ -63,7 +189,7 @@ async def line_plot_tool(
     y_column: str,
     title: str = "Line Plot",
     output_path: str = "line_plot.png",
-) -> dict:
+) -> ToolResult:
     """
     Create a line plot from data file with comprehensive visualization options.
 
@@ -75,22 +201,21 @@ async def line_plot_tool(
         output_path: Absolute path where the plot image will be saved (supports PNG, PDF, SVG)
 
     Returns:
-        Dictionary containing:
-        - plot_info: Details about the generated plot including dimensions and format
-        - data_summary: Statistical summary of the plotted data
-        - file_details: Information about the output file size and location
-        - visualization_stats: Metrics about data points and trends
+        A result carrying both a rendered PNG preview (bounded to ~800px
+        wide) and a structured dict: status, plot_type, output_path (the
+        full-resolution file on disk), x_column, y_column, title, and
+        data_points.
     """
     logger.info(f"Creating line plot from {file_path}")
     result = create_line_plot(file_path, x_column, y_column, title, output_path)
     if result.get("status") == "error":
         raise ToolError(result["error"])
-    return result
+    return _plot_tool_result(result)
 
 
 @mcp.tool(
     name="bar_plot",
-    title="plot(bar)",
+    title="Bar Plot",
     description="Create a bar chart from CSV or Excel data with categorical grouping.",
     annotations={
         "readOnlyHint": False,
@@ -98,6 +223,7 @@ async def line_plot_tool(
         "idempotentHint": True,
     },
     tags={"plot", "bar-chart", "visualization"},
+    output_schema=TypeAdapter(BarPlotResult).json_schema(mode="serialization"),
 )
 async def bar_plot_tool(
     file_path: str,
@@ -105,7 +231,7 @@ async def bar_plot_tool(
     y_column: str,
     title: str = "Bar Plot",
     output_path: str = "bar_plot.png",
-) -> dict:
+) -> ToolResult:
     """
     Create a bar plot from data file with comprehensive customization options.
 
@@ -117,22 +243,21 @@ async def bar_plot_tool(
         output_path: Absolute path where the plot image will be saved (supports PNG, PDF, SVG)
 
     Returns:
-        Dictionary containing:
-        - plot_info: Details about the generated bar chart including bar count and styling
-        - data_summary: Statistical summary of the categorical and numerical data
-        - file_details: Information about the output file size and location
-        - visualization_stats: Metrics about data distribution and categories
+        A result carrying both a rendered PNG preview (bounded to ~800px
+        wide) and a structured dict: status, plot_type, output_path (the
+        full-resolution file on disk), x_column, y_column, title,
+        data_points, and whether the bars were aggregated by mean.
     """
     logger.info(f"Creating bar plot from {file_path}")
     result = create_bar_plot(file_path, x_column, y_column, title, output_path)
     if result.get("status") == "error":
         raise ToolError(result["error"])
-    return result
+    return _plot_tool_result(result)
 
 
 @mcp.tool(
     name="scatter_plot",
-    title="plot(scatter)",
+    title="Scatter Plot",
     description="Create a scatter plot from CSV or Excel data for correlation analysis.",
     annotations={
         "readOnlyHint": False,
@@ -140,6 +265,7 @@ async def bar_plot_tool(
         "idempotentHint": True,
     },
     tags={"plot", "scatter-plot", "visualization"},
+    output_schema=TypeAdapter(ScatterPlotResult).json_schema(mode="serialization"),
 )
 async def scatter_plot_tool(
     file_path: str,
@@ -147,7 +273,7 @@ async def scatter_plot_tool(
     y_column: str,
     title: str = "Scatter Plot",
     output_path: str = "scatter_plot.png",
-) -> dict:
+) -> ToolResult:
     """
     Create a scatter plot from data file with advanced correlation analysis.
 
@@ -159,22 +285,21 @@ async def scatter_plot_tool(
         output_path: Absolute path where the plot image will be saved (supports PNG, PDF, SVG)
 
     Returns:
-        Dictionary containing:
-        - plot_info: Details about the generated scatter plot including point count and styling
-        - correlation_stats: Statistical correlation metrics and trend analysis
-        - data_summary: Statistical summary of both x and y variables
-        - file_details: Information about the output file size and location
+        A result carrying both a rendered PNG preview (bounded to ~800px
+        wide) and a structured dict: status, plot_type, output_path (the
+        full-resolution file on disk), x_column, y_column, title, and
+        data_points.
     """
     logger.info(f"Creating scatter plot from {file_path}")
     result = create_scatter_plot(file_path, x_column, y_column, title, output_path)
     if result.get("status") == "error":
         raise ToolError(result["error"])
-    return result
+    return _plot_tool_result(result)
 
 
 @mcp.tool(
     name="histogram_plot",
-    title="plot(histogram)",
+    title="Histogram",
     description="Create a histogram from CSV or Excel data showing value distribution.",
     annotations={
         "readOnlyHint": False,
@@ -182,6 +307,7 @@ async def scatter_plot_tool(
         "idempotentHint": True,
     },
     tags={"plot", "histogram", "visualization"},
+    output_schema=TypeAdapter(HistogramResult).json_schema(mode="serialization"),
 )
 async def histogram_plot_tool(
     file_path: str,
@@ -189,7 +315,7 @@ async def histogram_plot_tool(
     bins: int = 30,
     title: str = "Histogram",
     output_path: str = "histogram.png",
-) -> dict:
+) -> ToolResult:
     """
     Create a histogram from data file with advanced statistical analysis.
 
@@ -201,22 +327,20 @@ async def histogram_plot_tool(
         output_path: Absolute path where the plot image will be saved (supports PNG, PDF, SVG)
 
     Returns:
-        Dictionary containing:
-        - plot_info: Details about the generated histogram including bin information
-        - distribution_stats: Statistical metrics including mean, median, mode, and standard deviation
-        - data_summary: Comprehensive summary of the data distribution
-        - file_details: Information about the output file size and location
+        A result carrying both a rendered PNG preview (bounded to ~800px
+        wide) and a structured dict: status, plot_type, output_path (the
+        full-resolution file on disk), column, bins, title, and data_points.
     """
     logger.info(f"Creating histogram from {file_path}")
     result = create_histogram(file_path, column, bins, title, output_path)
     if result.get("status") == "error":
         raise ToolError(result["error"])
-    return result
+    return _plot_tool_result(result)
 
 
 @mcp.tool(
     name="heatmap_plot",
-    title="plot(heatmap)",
+    title="Heatmap",
     description="Create a correlation heatmap from numeric columns in CSV or Excel data.",
     annotations={
         "readOnlyHint": False,
@@ -224,10 +348,11 @@ async def histogram_plot_tool(
         "idempotentHint": True,
     },
     tags={"plot", "heatmap", "visualization"},
+    output_schema=TypeAdapter(HeatmapResult).json_schema(mode="serialization"),
 )
 async def heatmap_plot_tool(
     file_path: str, title: str = "Heatmap", output_path: str = "heatmap.png"
-) -> dict:
+) -> ToolResult:
     """
     Create a heatmap from data file with advanced correlation visualization.
 
@@ -237,22 +362,21 @@ async def heatmap_plot_tool(
         output_path: Absolute path where the plot image will be saved (supports PNG, PDF, SVG)
 
     Returns:
-        Dictionary containing:
-        - plot_info: Details about the generated heatmap including matrix dimensions
-        - correlation_matrix: Full correlation matrix with statistical significance
-        - data_summary: Statistical summary of all numerical variables
-        - file_details: Information about the output file size and location
+        A result carrying both a rendered PNG preview (bounded to ~800px
+        wide) and a structured dict: status, plot_type, output_path (the
+        full-resolution file on disk), title, data_points, and the numeric
+        columns included in the correlation matrix.
     """
     logger.info(f"Creating heatmap from {file_path}")
     result = create_heatmap(file_path, title, output_path)
     if result.get("status") == "error":
         raise ToolError(result["error"])
-    return result
+    return _plot_tool_result(result)
 
 
 @mcp.tool(
     name="plot_timeseries",
-    title="plot(timeseries)",
+    title="Timeseries Plot",
     description="Create a multi-series line chart PNG from one or more y columns of a CSV or Excel file, auto-detecting a time, numeric, or categorical x axis.",
     annotations={
         "readOnlyHint": False,
@@ -260,6 +384,7 @@ async def heatmap_plot_tool(
         "idempotentHint": True,
     },
     tags={"plot", "line-chart", "timeseries", "visualization"},
+    output_schema=TypeAdapter(TimeseriesPlotResult).json_schema(mode="serialization"),
 )
 async def plot_timeseries(
     data_path: str,
@@ -273,7 +398,7 @@ async def plot_timeseries(
     output_path: str = "timeseries.png",
     title: str | None = None,
     max_rows: int = 2000,
-) -> dict:
+) -> ToolResult:
     """
     Create a time-series line plot from one or more columns of a data file.
 
@@ -293,11 +418,11 @@ async def plot_timeseries(
         max_rows: Maximum number of leading rows to read and plot
 
     Returns:
-        Dictionary containing:
-        - plot_info: Details about the generated plot including the resolved y columns
-        - x_axis: The inferred x-axis kind, label, and parse-success ratio
-        - data_summary: Number of data points plotted
-        - file_details: Information about the output file location
+        A result carrying both a rendered PNG preview (bounded to ~800px
+        wide) and a structured dict: status, plot_type, output_path (the
+        full-resolution file on disk), x_column, the inferred x_axis (kind,
+        label, parse_success_ratio), the resolved y_columns, title, and
+        data_points.
     """
     logger.info(f"Creating timeseries plot from {data_path}")
     result = create_timeseries_plot(
@@ -305,12 +430,12 @@ async def plot_timeseries(
     )
     if result.get("status") == "error":
         raise ToolError(result["error"])
-    return result
+    return _plot_tool_result(result)
 
 
 @mcp.tool(
     name="data_info",
-    title="describe(data)",
+    title="Describe Data",
     description="Get schema, column types, and summary statistics for a CSV or Excel file.",
     annotations={
         "readOnlyHint": True,
@@ -319,7 +444,7 @@ async def plot_timeseries(
     },
     tags={"data", "analysis", "visualization"},
 )
-async def data_info_tool(file_path: str) -> dict:
+async def data_info_tool(file_path: str) -> DataInfoResult:
     """
     Get comprehensive data file information with detailed analysis.
 
@@ -327,17 +452,15 @@ async def data_info_tool(file_path: str) -> dict:
         file_path: Absolute path to CSV or Excel file
 
     Returns:
-        Dictionary containing:
-        - data_schema: Column names, data types, and null value analysis
-        - data_quality: Missing values, duplicates, and data consistency metrics
-        - statistical_summary: Basic statistics for numerical and categorical columns
-        - visualization_recommendations: Suggested plot types based on data characteristics
+        Dictionary containing status, file_path, shape (rows, columns),
+        columns, dtypes, null_counts, memory_usage, and a JSON preview of the
+        first rows (head).
     """
     logger.info(f"Getting data info for {file_path}")
     result = get_data_info(file_path)
     if result.get("status") == "error":
         raise ToolError(result["error"])
-    return result
+    return cast(DataInfoResult, result)
 
 
 @mcp.resource("plot://styles")

--- a/clio-kit-mcp-servers/plot/src/plot_mcp/server.py
+++ b/clio-kit-mcp-servers/plot/src/plot_mcp/server.py
@@ -6,7 +6,7 @@ pandas and matplotlib.
 """
 
 import os
-from typing import Annotated, Any, Literal, TypedDict, cast
+from typing import Annotated, Any, Literal, cast
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
@@ -15,6 +15,7 @@ from fastmcp.tools import ToolResult
 from fastmcp.utilities.types import Image
 from dotenv import load_dotenv
 from pydantic import Field, TypeAdapter
+from typing_extensions import TypedDict
 import logging
 from .implementation.plot_capabilities import (
     create_line_plot,

--- a/clio-kit-mcp-servers/plot/tests/test_handlers.py
+++ b/clio-kit-mcp-servers/plot/tests/test_handlers.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 import asyncio
 
+from fastmcp.tools import ToolResult
 from plot_mcp import server
 from plot_mcp.implementation.plot_capabilities import (
     create_line_plot,
@@ -17,6 +18,16 @@ from plot_mcp.implementation.plot_capabilities import (
     create_heatmap,
     get_data_info,
 )
+
+
+def _assert_plot_tool_result(result: ToolResult) -> None:
+    """A plot tool result carries a PNG image block plus the structured dict."""
+    assert isinstance(result, ToolResult)
+    assert result.structured_content is not None
+    assert result.structured_content["status"] == "success"
+    image_blocks = [c for c in result.content if c.type == "image"]
+    assert image_blocks, "expected an image content block"
+    assert image_blocks[0].mime_type == "image/png"
 
 
 class TestHandlers:
@@ -193,7 +204,7 @@ class TestHandlers:
                 title="MCP Line Plot",
                 output_path=f.name,
             )
-            assert isinstance(result, dict)
+            _assert_plot_tool_result(result)
         os.unlink(f.name)
 
         # Test bar_plot_tool
@@ -205,7 +216,7 @@ class TestHandlers:
                 title="MCP Bar Plot",
                 output_path=f.name,
             )
-            assert isinstance(result, dict)
+            _assert_plot_tool_result(result)
         os.unlink(f.name)
 
         # Test scatter_plot_tool
@@ -217,7 +228,7 @@ class TestHandlers:
                 title="MCP Scatter Plot",
                 output_path=f.name,
             )
-            assert isinstance(result, dict)
+            _assert_plot_tool_result(result)
         os.unlink(f.name)
 
         # Test histogram_plot_tool
@@ -229,7 +240,7 @@ class TestHandlers:
                 title="MCP Histogram",
                 output_path=f.name,
             )
-            assert isinstance(result, dict)
+            _assert_plot_tool_result(result)
         os.unlink(f.name)
 
         # Test heatmap_plot_tool
@@ -237,7 +248,7 @@ class TestHandlers:
             result = await server.heatmap_plot_tool(
                 file_path=sample_csv_file, title="MCP Heatmap", output_path=f.name
             )
-            assert isinstance(result, dict)
+            _assert_plot_tool_result(result)
         os.unlink(f.name)
 
     def test_handler_parameter_validation(self, sample_csv_file):
@@ -421,10 +432,13 @@ class TestHandlers:
             # Execute all async tests
             results = await asyncio.gather(*async_tests)
 
-            # Verify all results
-            for result in results:
-                assert isinstance(result, dict)
-                assert "status" in result
+            # Verify all results: data_info_tool returns a plain dict, the
+            # five plot tools each return a ToolResult (image + structured).
+            data_info_result, *plot_results = results
+            assert isinstance(data_info_result, dict)
+            assert "status" in data_info_result
+            for result in plot_results:
+                _assert_plot_tool_result(result)
 
         # Cleanup
         for f in [f1, f2, f3, f4, f5]:

--- a/clio-kit-mcp-servers/plot/tests/test_output_content.py
+++ b/clio-kit-mcp-servers/plot/tests/test_output_content.py
@@ -1,0 +1,173 @@
+"""Verify plot tools declare real MCP output semantics (2026-07-28 protocol).
+
+Every image-producing plot tool must return a proper MCP ``ImageContent``
+block (base64 PNG) alongside its structured dict, and every plot tool's
+registration must advertise a real ``outputSchema`` — not just the generic
+``{"type": "object"}`` a bare ``-> dict`` annotation would produce.
+
+These tests drive the server through an in-memory ``fastmcp.Client``, so they
+exercise exactly what a real MCP client sees on the wire.
+"""
+
+import base64
+import os
+import tempfile
+
+import pandas as pd
+import pytest
+from fastmcp import Client
+
+from plot_mcp.server import mcp
+
+IMAGE_TOOL_NAMES = {
+    "line_plot",
+    "bar_plot",
+    "scatter_plot",
+    "histogram_plot",
+    "heatmap_plot",
+    "plot_timeseries",
+}
+
+# Every plot tool -- including data_info, which has no image -- must declare
+# a real, field-level output schema (not a bare {"type": "object"}).
+ALL_TOOL_NAMES = IMAGE_TOOL_NAMES | {"data_info"}
+
+
+@pytest.fixture
+def sample_csv_file():
+    """A small CSV with numeric and categorical columns for every plot kind."""
+    data = pd.DataFrame(
+        {
+            "x": [1, 2, 3, 4, 5],
+            "y": [2, 4, 6, 8, 10],
+            "category": ["A", "B", "A", "B", "A"],
+            "value": [10, 20, 15, 25, 30],
+        }
+    )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        data.to_csv(f.name, index=False)
+        yield f.name
+    os.unlink(f.name)
+
+
+@pytest.mark.asyncio
+async def test_tools_list_advertises_real_output_schemas() -> None:
+    """tools/list must show a field-level outputSchema for every plot tool."""
+    async with Client(mcp) as client:
+        tools = {tool.name: tool for tool in await client.list_tools()}
+
+    missing = ALL_TOOL_NAMES - set(tools)
+    assert not missing, f"tools missing from tools/list: {missing}"
+
+    for name in ALL_TOOL_NAMES:
+        schema = tools[name].output_schema
+        assert schema is not None, f"{name} has no outputSchema"
+        assert schema.get("type") == "object", f"{name} outputSchema is not an object"
+        properties = schema.get("properties")
+        assert properties, f"{name} outputSchema has no real field properties: {schema}"
+        # "status" is common to every structured plot/data result.
+        assert "status" in properties, f"{name} outputSchema missing 'status' field"
+
+
+@pytest.mark.asyncio
+async def test_line_plot_returns_image_content_and_structured_dict(
+    sample_csv_file,
+) -> None:
+    """A plot tool call returns both an image/png content block and intact
+    structuredContent (with output_path still pointing at the full-res file)."""
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        output_path = f.name
+
+    async with Client(mcp) as client:
+        result = await client.call_tool_mcp(
+            "line_plot",
+            {
+                "file_path": sample_csv_file,
+                "x_column": "x",
+                "y_column": "y",
+                "title": "Content Test",
+                "output_path": output_path,
+            },
+        )
+
+    try:
+        assert not result.is_error
+
+        image_blocks = [c for c in result.content if c.type == "image"]
+        assert image_blocks, "expected an ImageContent block in the response"
+        image = image_blocks[0]
+        assert image.mime_type == "image/png"
+        # The data must be valid, non-trivial base64-encoded PNG bytes.
+        decoded = base64.b64decode(image.data)
+        assert decoded.startswith(b"\x89PNG\r\n\x1a\n")
+        assert len(decoded) > 0
+
+        structured = result.structured_content
+        assert structured is not None
+        assert structured["status"] == "success"
+        assert structured["plot_type"] == "line"
+        assert structured["output_path"] == output_path
+        assert structured["data_points"] == 5
+
+        # The full-resolution file on disk is untouched and independent
+        # of the (possibly downscaled) embedded preview.
+        assert os.path.exists(output_path)
+        with open(output_path, "rb") as full_res:
+            full_res_bytes = full_res.read()
+        assert len(full_res_bytes) > 0
+    finally:
+        os.unlink(output_path)
+
+
+@pytest.mark.asyncio
+async def test_preview_is_bounded_even_when_full_res_is_large(
+    sample_csv_file,
+) -> None:
+    """The embedded preview must stay small regardless of the on-disk size."""
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        output_path = f.name
+
+    async with Client(mcp) as client:
+        result = await client.call_tool_mcp(
+            "heatmap_plot",
+            {
+                "file_path": sample_csv_file,
+                "title": "Bounded Preview Test",
+                "output_path": output_path,
+            },
+        )
+
+    try:
+        image = next(c for c in result.content if c.type == "image")
+        decoded = base64.b64decode(image.data)
+
+        from PIL import Image as PILImage
+        import io
+
+        with PILImage.open(io.BytesIO(decoded)) as preview:
+            assert preview.width <= 800
+
+        # A downscaled, optimized PNG preview of a simple chart should
+        # comfortably stay well under a megabyte on the wire.
+        assert len(decoded) < 1_000_000
+    finally:
+        os.unlink(output_path)
+
+
+@pytest.mark.asyncio
+async def test_data_info_has_no_image_but_has_structured_content(
+    sample_csv_file,
+) -> None:
+    """data_info produces no plot, so it carries no image content block, but
+    it still returns intact structured content matching its output schema."""
+    async with Client(mcp) as client:
+        result = await client.call_tool_mcp("data_info", {"file_path": sample_csv_file})
+
+    assert not result.is_error
+    image_blocks = [c for c in result.content if c.type == "image"]
+    assert not image_blocks, "data_info should not carry an image content block"
+
+    structured = result.structured_content
+    assert structured is not None
+    assert structured["status"] == "success"
+    assert structured["columns"] == ["x", "y", "category", "value"]

--- a/clio-kit-mcp-servers/plot/tests/test_server.py
+++ b/clio-kit-mcp-servers/plot/tests/test_server.py
@@ -8,7 +8,18 @@ import pandas as pd
 import pytest
 
 from fastmcp.exceptions import ToolError
+from fastmcp.tools import ToolResult
 from plot_mcp import server
+
+
+def _assert_plot_tool_result(result: ToolResult) -> None:
+    """A plot tool result carries a PNG image block plus the structured dict."""
+    assert isinstance(result, ToolResult)
+    assert result.structured_content is not None
+    assert result.structured_content["status"] == "success"
+    image_blocks = [c for c in result.content if c.type == "image"]
+    assert image_blocks, "expected an image content block"
+    assert image_blocks[0].mime_type == "image/png"
 
 
 class TestServer:
@@ -128,8 +139,7 @@ class TestServer:
                 title="Test Line Plot",
                 output_path=f.name,
             )
-            assert isinstance(result, dict)
-            assert "status" in result
+            _assert_plot_tool_result(result)
         os.unlink(f.name)
 
     @pytest.mark.asyncio
@@ -143,8 +153,7 @@ class TestServer:
                 title="Test Bar Plot",
                 output_path=f.name,
             )
-            assert isinstance(result, dict)
-            assert "status" in result
+            _assert_plot_tool_result(result)
         os.unlink(f.name)
 
     @pytest.mark.asyncio
@@ -158,8 +167,7 @@ class TestServer:
                 title="Test Scatter Plot",
                 output_path=f.name,
             )
-            assert isinstance(result, dict)
-            assert "status" in result
+            _assert_plot_tool_result(result)
         os.unlink(f.name)
 
     @pytest.mark.asyncio
@@ -173,8 +181,7 @@ class TestServer:
                 title="Test Histogram",
                 output_path=f.name,
             )
-            assert isinstance(result, dict)
-            assert "status" in result
+            _assert_plot_tool_result(result)
         os.unlink(f.name)
 
     @pytest.mark.asyncio
@@ -184,8 +191,7 @@ class TestServer:
             result = await server.heatmap_plot_tool(
                 file_path=sample_csv_file, title="Test Heatmap", output_path=f.name
             )
-            assert isinstance(result, dict)
-            assert "status" in result
+            _assert_plot_tool_result(result)
         os.unlink(f.name)
 
     @pytest.mark.asyncio

--- a/clio-kit-mcp-servers/plot/tests/test_timeseries.py
+++ b/clio-kit-mcp-servers/plot/tests/test_timeseries.py
@@ -12,6 +12,7 @@ import tempfile
 import pandas as pd
 import pytest
 from fastmcp.exceptions import ToolError
+from fastmcp.tools import ToolResult
 
 from plot_mcp import server
 from plot_mcp.implementation.plot_capabilities import (
@@ -285,9 +286,14 @@ async def test_plot_timeseries_tool_success(datetime_csv):
             output_path=f.name,
             title="MCP Timeseries",
         )
-        assert isinstance(result, dict)
-        assert result["status"] == "success"
-        assert result["y_columns"] == ["pressure", "temperature"]
+        assert isinstance(result, ToolResult)
+        structured = result.structured_content
+        assert structured is not None
+        assert structured["status"] == "success"
+        assert structured["y_columns"] == ["pressure", "temperature"]
+        image_blocks = [c for c in result.content if c.type == "image"]
+        assert image_blocks, "expected an image content block"
+        assert image_blocks[0].mime_type == "image/png"
         assert os.path.exists(f.name)
     os.unlink(f.name)
 
@@ -301,7 +307,8 @@ async def test_plot_timeseries_tool_comma_string(datetime_csv):
             y_columns="temperature,pressure",
             output_path=f.name,
         )
-        assert result["status"] == "success"
+        assert result.structured_content is not None
+        assert result.structured_content["status"] == "success"
     os.unlink(f.name)
 
 

--- a/clio-kit-mcp-servers/plot/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/plot/tests/test_tool_titles.py
@@ -43,8 +43,19 @@ async def test_titles_are_distinct_within_server() -> None:
 
 @pytest.mark.asyncio
 async def test_plot_timeseries_title_matches_project_owner_mapping() -> None:
-    """The owner's exact given mapping for this tool: plot_timeseries -> plot(timeseries)."""
+    """The owner's exact given mapping for this tool: plot_timeseries -> Timeseries Plot."""
     async with Client(mcp) as client:
         tools = {tool.name: tool for tool in await client.list_tools()}
 
-    assert tools["plot_timeseries"].title == "plot(timeseries)"
+    assert tools["plot_timeseries"].title == "Timeseries Plot"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/src/sac_mcp/server.py
+++ b/clio-kit-mcp-servers/sac/src/sac_mcp/server.py
@@ -45,7 +45,7 @@ mcp: FastMCP = FastMCP(
 
 @mcp.tool(
     name="inspect_archive",
-    title="inspect(archive)",
+    title="Inspect Archive",
     description=(
         "Inspect a staged SAC file or TAR archive and summarize its SAC waveform "
         "members: count, a sample of member names and sizes, and the inferred "
@@ -90,7 +90,7 @@ async def inspect_archive_tool(
 
 @mcp.tool(
     name="compute_trace_statistics",
-    title="stats(traces)",
+    title="Trace Statistics",
     description=(
         "Compute per-trace amplitude statistics (min, max, mean, std, peak_abs) "
         "plus header metadata (npts, delta_s, begin_s, end_s) for SAC traces in a "
@@ -134,7 +134,7 @@ async def compute_trace_statistics_tool(
 
 @mcp.tool(
     name="plot_traces",
-    title="plot(traces)",
+    title="Plot Traces",
     description=(
         "Plot selected SAC traces from a file or archive to a PNG artifact. Traces "
         "are amplitude-normalized and vertically offset. Writes a file; returns the "

--- a/clio-kit-mcp-servers/sac/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/sac/tests/test_tool_titles.py
@@ -15,3 +15,14 @@ async def test_all_tools_have_compact_titles() -> None:
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/src/scientific_catalog_mcp/server.py
+++ b/clio-kit-mcp-servers/scientific-catalog/src/scientific_catalog_mcp/server.py
@@ -60,7 +60,7 @@ def _store() -> CatalogStore:
 
 @mcp.tool(
     name="scientific_dataset_search",
-    title="search(dataset)",
+    title="Search Datasets",
     description=(
         "Search operator-registered scientific datasets and return bounded intrinsic summaries."
     ),
@@ -96,7 +96,7 @@ def scientific_dataset_search_tool(
 
 @mcp.tool(
     name="scientific_dataset_describe",
-    title="describe(dataset)",
+    title="Describe Dataset",
     description=(
         "Return one exact operator catalog record plus a top-level dataset_descriptor. "
         "Pass dataset_descriptor unchanged as jarvis_add_step config.dataset_descriptor; "

--- a/clio-kit-mcp-servers/scientific-catalog/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/scientific-catalog/tests/test_tool_titles.py
@@ -15,3 +15,14 @@ async def test_all_tools_have_compact_titles() -> None:
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/src/seismic_mcp/server.py
+++ b/clio-kit-mcp-servers/seismic/src/seismic_mcp/server.py
@@ -51,7 +51,7 @@ mcp: FastMCP = FastMCP(
 
 @mcp.tool(
     name="analyze_sequence",
-    title="analyze(sequence)",
+    title="Analyze Sequence",
     description=(
         "Compute the descriptive statistics of a saved earthquake catalog: "
         "completeness magnitude (Mc), the Gutenberg-Richter b-value with "
@@ -97,7 +97,7 @@ async def analyze_sequence_tool(
 
 @mcp.tool(
     name="plot_sequence",
-    title="plot(sequence)",
+    title="Plot Sequence",
     description=(
         "Render the three-panel earthquake-sequence figure from a saved catalog: "
         "(1) an epicenter map sized by magnitude and coloured by time, (2) the "

--- a/clio-kit-mcp-servers/seismic/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/seismic/tests/test_tool_titles.py
@@ -23,3 +23,14 @@ async def test_every_tool_has_a_short_title() -> None:
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/src/slurm_mcp/server.py
+++ b/clio-kit-mcp-servers/slurm/src/slurm_mcp/server.py
@@ -89,7 +89,7 @@ class SlurmMCPError(Exception):
 
 @mcp.tool(
     name="slurm_submit",
-    title="submit(job)",
+    title="Submit Job",
     description=(
         "Submit one Slurm job or array and return its scheduler-native job ID. "
         "Set array only for an array submission."
@@ -130,7 +130,7 @@ async def slurm_submit_tool(
 
 @mcp.tool(
     name="slurm_list",
-    title="list(jobs)",
+    title="List Jobs",
     description=(
         "List a bounded number of Slurm jobs with optional user, state, and "
         "partition filters. Returns native IDs and explicit truncation state."
@@ -160,7 +160,7 @@ async def slurm_list_tool(
 
 @mcp.tool(
     name="slurm_describe",
-    title="describe(job)",
+    title="Describe Job",
     description=(
         "Describe one scheduler-native Slurm job: lifecycle state, terminality, "
         "scheduler properties, and optional bounded stdout/stderr tails."
@@ -193,7 +193,7 @@ async def slurm_describe_tool(
 
 @mcp.tool(
     name="slurm_cluster",
-    title="snapshot(cluster)",
+    title="Cluster Snapshot",
     description=(
         "Inspect bounded Slurm partition and queue records in one snapshot. "
         "Node details are excluded by default and bounded when requested."
@@ -228,7 +228,7 @@ async def slurm_cluster_tool(
 
 @mcp.tool(
     name="slurm_cancel",
-    title="cancel(job)",
+    title="Cancel Job",
     description=(
         "Request destructive cancellation of one Slurm job. confirm_job_id must "
         "exactly repeat job_id; omission or mismatch is rejected without calling scancel."
@@ -266,7 +266,7 @@ async def slurm_cancel_tool(
 
 @mcp.tool(
     name="submit_slurm_job",
-    title="submit(slurm job)",
+    title="Submit Slurm Job",
     description="Submit a job script to the Slurm scheduler with resource requirements.",
     annotations={
         "readOnlyHint": False,
@@ -309,7 +309,7 @@ async def submit_slurm_job_tool(
 
 @mcp.tool(
     name="check_job_status",
-    title="check(job status)",
+    title="Check Job Status",
     description="Check the status of a Slurm job by its ID.",
     annotations={
         "readOnlyHint": True,
@@ -338,7 +338,7 @@ async def check_job_status_tool(job_id: str) -> dict:
 
 @mcp.tool(
     name="cancel_slurm_job",
-    title="cancel(slurm job)",
+    title="Cancel Slurm Job",
     description="Cancel a running or pending Slurm job.",
     annotations={
         "readOnlyHint": False,
@@ -366,7 +366,7 @@ async def cancel_slurm_job_tool(job_id: str) -> dict:
 
 @mcp.tool(
     name="list_slurm_jobs",
-    title="list(slurm jobs)",
+    title="List Slurm Jobs",
     description="List Slurm jobs with optional filtering by user and state.",
     annotations={
         "readOnlyHint": True,
@@ -397,7 +397,7 @@ async def list_slurm_jobs_tool(
 
 @mcp.tool(
     name="get_slurm_info",
-    title="get(cluster info)",
+    title="Get Cluster Info",
     description="Get Slurm cluster configuration, partitions, and resource availability.",
     annotations={
         "readOnlyHint": True,
@@ -422,7 +422,7 @@ async def get_slurm_info_tool() -> dict:
 
 @mcp.tool(
     name="get_job_details",
-    title="get(job details)",
+    title="Get Job Details",
     description="Get detailed information about a specific Slurm job.",
     annotations={
         "readOnlyHint": True,
@@ -450,7 +450,7 @@ async def get_job_details_tool(job_id: str) -> dict:
 
 @mcp.tool(
     name="get_job_output",
-    title="get(job output)",
+    title="Get Job Output",
     description="Retrieve stdout or stderr output from a Slurm job.",
     annotations={
         "readOnlyHint": True,
@@ -479,7 +479,7 @@ async def get_job_output_tool(job_id: str, output_type: str = "stdout") -> dict:
 
 @mcp.tool(
     name="get_queue_info",
-    title="get(queue info)",
+    title="Get Queue Info",
     description="Get Slurm queue status and partition information.",
     annotations={
         "readOnlyHint": True,
@@ -507,7 +507,7 @@ async def get_queue_info_tool(partition: Optional[str] = None) -> dict:
 
 @mcp.tool(
     name="submit_array_job",
-    title="submit(array job)",
+    title="Submit Array Job",
     description="Submit a Slurm array job for parallel task execution.",
     annotations={
         "readOnlyHint": False,
@@ -553,7 +553,7 @@ async def submit_array_job_tool(
 
 @mcp.tool(
     name="get_node_info",
-    title="get(node info)",
+    title="Get Node Info",
     description="Get information about Slurm cluster nodes and their resources.",
     annotations={
         "readOnlyHint": True,
@@ -578,7 +578,7 @@ async def get_node_info_tool() -> dict:
 
 @mcp.tool(
     name="allocate_slurm_nodes",
-    title="allocate(nodes)",
+    title="Allocate Nodes",
     description="Allocate Slurm nodes for an interactive session using salloc.",
     annotations={
         "readOnlyHint": False,
@@ -622,7 +622,7 @@ async def allocate_slurm_nodes_tool(
 
 @mcp.tool(
     name="deallocate_slurm_nodes",
-    title="release(allocation)",
+    title="Release Allocation",
     description="Release a Slurm node allocation by canceling it.",
     annotations={
         "readOnlyHint": False,
@@ -650,7 +650,7 @@ async def deallocate_slurm_nodes_tool(allocation_id: str) -> dict:
 
 @mcp.tool(
     name="get_allocation_status",
-    title="check(allocation)",
+    title="Check Allocation",
     description="Check the status of a Slurm node allocation.",
     annotations={
         "readOnlyHint": True,

--- a/clio-kit-mcp-servers/slurm/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/slurm/tests/test_tool_titles.py
@@ -59,3 +59,14 @@ async def test_titles_are_distinct_within_server(mcp) -> None:
 
     titles = [tool.title for tool in tools]
     assert len(titles) == len(set(titles)), "Duplicate titles found within slurm server"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses(mcp) -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/src/spack_mcp/server.py
+++ b/clio-kit-mcp-servers/spack/src/spack_mcp/server.py
@@ -47,7 +47,7 @@ ResultT = TypeVar("ResultT")
 
 @mcp.tool(
     name="spack_find",
-    title="find(packages)",
+    title="Find Packages",
     description=(
         "List installed Spack packages matching an optional constraint. "
         "No matches is a successful result with count=0 and packages=[]."
@@ -67,7 +67,7 @@ async def spack_find_tool(query: str | None = None) -> SpackFindResult:
 
 @mcp.tool(
     name="spack_locate",
-    title="locate(package)",
+    title="Locate Package",
     description=(
         "Resolve one unique installed Spack spec. Copy "
         "spack_locate.output.load_spec unchanged into one element of "
@@ -90,7 +90,7 @@ async def spack_locate_tool(spec: str) -> SpackLocateResult:
 
 @mcp.tool(
     name="spack_install",
-    title="install(package)",
+    title="Install Package",
     description=(
         "Install one Spack spec with explicit reusable or fresh concretization and "
         "verify that a matching install is observable."
@@ -128,7 +128,7 @@ async def spack_install_tool(
 
 @mcp.tool(
     name="spack_environment",
-    title="diff(environment)",
+    title="Diff Environment",
     description=(
         "Admin diagnostic: return a filtered structured environment for installed specs. "
         "This does not mutate the MCP server or any later process."

--- a/clio-kit-mcp-servers/spack/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/spack/tests/test_tool_titles.py
@@ -30,3 +30,14 @@ async def test_every_tool_has_a_short_title() -> None:
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/src/terrain_mcp/server.py
+++ b/clio-kit-mcp-servers/terrain/src/terrain_mcp/server.py
@@ -48,7 +48,7 @@ mcp: FastMCP = FastMCP(
 
 @mcp.tool(
     name="dem_terrain",
-    title="analyze(dem)",
+    title="Analyze DEM",
     description=(
         "Analyze a Digital Elevation Model grid for elevation, slope, aspect, and "
         "site suitability. Accepts CSV numeric grids, NPY, and NPZ (with a 'dem' "
@@ -108,7 +108,7 @@ async def dem_terrain_tool(
 
 @mcp.tool(
     name="pointcloud_read",
-    title="grid(points)",
+    title="Grid Points",
     description=(
         "Read an x/y/z point cloud and grid it into a DEM-like surface by averaging "
         "z per cell. Accepts CSV with x,y,z columns, NPY, and NPZ; LAS/LAZ requires "

--- a/clio-kit-mcp-servers/terrain/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/terrain/tests/test_tool_titles.py
@@ -15,3 +15,14 @@ async def test_all_tools_have_compact_titles() -> None:
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/web/server.json
+++ b/clio-kit-mcp-servers/web/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/web/src/web_mcp/server.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/server.py
@@ -433,7 +433,7 @@ async def _download(
 
 @mcp.tool(
     name="fetch",
-    title="fetch(url)",
+    title="Fetch URL",
     description=(
         "Fetch an HTTP(S) URL with a streamed size cap and timeout, convert "
         "HTML to Markdown, and return the content inline or (to_file=True) "
@@ -647,7 +647,7 @@ async def _search_tavily(query: str, count: int) -> list[dict[str, str]]:
 
 @mcp.tool(
     name="search",
-    title="search(web)",
+    title="Search Web",
     description=(
         "Search the web via a configurable provider (keyless DuckDuckGo by "
         "default; optional BYO-key Brave or Tavily) and return ranked results."

--- a/clio-kit-mcp-servers/web/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/web/tests/test_tool_titles.py
@@ -15,3 +15,14 @@ async def test_all_tools_have_compact_titles() -> None:
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"
+
+
+@pytest.mark.asyncio
+async def test_titles_have_no_parentheses() -> None:
+    """Titles are plain Title Case names; parens are a UI-injected call-arg
+    decoration, not part of the tool's display title (2.7.1 rename)."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    with_parens = [tool.name for tool in tools if tool.title and "(" in tool.title]
+    assert not with_parens, f"Tools with parens in title: {with_parens}"

--- a/clio-kit-mcp-servers/web/uv.lock
+++ b/clio-kit-mcp-servers/web/uv.lock
@@ -930,15 +930,15 @@ wheels = [
 
 [[package]]
 name = "h2"
-version = "4.4.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d4/a7d6fb3f58be99d65cbf2d3f766896217a2921d0f3ab10711c45dc1519ee/h2-4.4.0.tar.gz", hash = "sha256:46b551bdcdc7e83cf5c04d0bf93badb8a939bd2287d9fee1abb23a445b9e0580", size = 2156691, upload-time = "2026-07-23T19:14:19.442Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/df/5b14a118322d6097cb9bb30ec6bacad268e546a8ecfcb1f6d0de618dac2f/h2-4.4.0-py3-none-any.whl", hash = "sha256:6acffe1aeab79098d7eb0f8385c1add11f2c7a94815f6fa2b7060eeddee3d87c", size = 62368, upload-time = "2026-07-23T19:14:16.143Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
 ]
 
 [[package]]
@@ -1017,15 +1017,6 @@ http2 = [
 ]
 socks = [
     { name = "socksio" },
-]
-
-[[package]]
-name = "httpx-sse"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.7.0"
+version = "2.7.1"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/clio_kit/_mcp_contracts/index.json
+++ b/src/clio_kit/_mcp_contracts/index.json
@@ -2,39 +2,39 @@
   "contracts": [
     {
       "artifact": "jarvis-user-v3.6.json",
-      "artifact_sha256": "b4cabd8715813a7cfd0e27b6aa8d9aba94cc60ae6ccba98fc76e310d41ac4547",
+      "artifact_sha256": "08c86eda618ec83109fa3c86fe28eccfd44c1ed0e647b93bcb0a82e470fd0d5e",
       "contract_id": "clio-kit-jarvis-user-v3.6",
-      "contract_sha256": "c845f7f72f0692aa3e0f28a5310a343ce116aae1e5542d3bc8a2a9de17b3296b",
+      "contract_sha256": "a326af259e50b57b19b7aa1d209720d5a71e57d7c2e64979596c4fc21850bdda",
       "profile": "user",
       "server_name": "jarvis",
-      "wire_sha256": "1353209b546f438430c55a86c066a4aedc84cc306f399d110c966d4c688f0bc7"
+      "wire_sha256": "0f912b4dfa7135448834f915984ca413f77b73ef53b0f758594006cd7551cd35"
     },
     {
       "artifact": "slurm-user-v3.json",
-      "artifact_sha256": "2a92deb6290123b2d33d622a7a8a78c0f844383cbd5d1280a331775d2997a558",
+      "artifact_sha256": "6252a8fe20406eed7fa6b643472d6ae90b5249f7832faf21ae9f47c264763bf7",
       "contract_id": "clio-kit-slurm-user-v3",
-      "contract_sha256": "b1783c194b60ad6b791582fbf1783d7f0770fddf2a880da1d78bc7c4069feeb7",
+      "contract_sha256": "f61b27b0c7d4648d86c27b29504688a13ba45767bd75bfc372c830308f7c05c0",
       "profile": "user",
       "server_name": "slurm",
-      "wire_sha256": "29dcc199e98f38cc4d3edcd97c081f486e37291c7b9b4d0477684b4e58642e40"
+      "wire_sha256": "8da5ea375d75d04052f766b02071fa4f41a2b61494b739e0e806eed02da532db"
     },
     {
       "artifact": "spack-user-v2.1.json",
-      "artifact_sha256": "f1e5cf00f3df13bdc60b5d84536ecbfa0b54b718b36ff61f5f9b4b2e7d418958",
+      "artifact_sha256": "b8da9a3cad05ad734ac3a20adb635f11fa45a8870afe08a9f4e261fdc713b57d",
       "contract_id": "clio-kit-spack-user-v2.1",
-      "contract_sha256": "c9415541797dab178d5bdc797c6c03b259b462139fd8ab4069334b9871aef7a0",
+      "contract_sha256": "4a065d2c67c0dd34e2cc18bca9dc53ed87ce35aa4ac524ef3e5c954a875c19db",
       "profile": "user",
       "server_name": "spack",
-      "wire_sha256": "898e43be33f7ab61130ee1b0b1ec5458f60e32ad27a1ad96fd806902266c9dc3"
+      "wire_sha256": "c7f1d1a4ce35b58664b46d2994863257a1e5a30e5c4ab7501b0a96a4becc08b7"
     },
     {
       "artifact": "scientific-catalog-user-v1.1.json",
-      "artifact_sha256": "5d3b7240297dfb79a93c9cdbb1e18aad8776480a63e90606af0e3bcbcfa5db2e",
+      "artifact_sha256": "8548aa8f0d1993ec644bb2fea778a4759b27d34bea3ed93ff92254b6fbf3052e",
       "contract_id": "clio-kit-scientific-catalog-user-v1.1",
-      "contract_sha256": "b5de9cd81ad2d8bab463b56669165535737a0954fa0a944b25da4a0c9325aaba",
+      "contract_sha256": "fd9fd4ba76617f1fd13560420cd650f78adc55d0957bd950d10d09c72ebe1889",
       "profile": "user",
       "server_name": "scientific-catalog",
-      "wire_sha256": "6b81cd7593c415df4b6f2a14e40df9b698ee8ea8d6cfd5a7adef4b8ef36b50e2"
+      "wire_sha256": "6a8fc61e31515880c722db3447d2f01584e4b297cb02b70b5618bff081840380"
     },
     {
       "artifact": "jarvis-user-v3.json",

--- a/src/clio_kit/_mcp_contracts/jarvis-user-v3.6.json
+++ b/src/clio_kit/_mcp_contracts/jarvis-user-v3.6.json
@@ -1,7 +1,7 @@
 {
   "canonicalization": "json-sort-keys-compact-utf8-v1",
   "contract_id": "clio-kit-jarvis-user-v3.6",
-  "contract_sha256": "c845f7f72f0692aa3e0f28a5310a343ce116aae1e5542d3bc8a2a9de17b3296b",
+  "contract_sha256": "a326af259e50b57b19b7aa1d209720d5a71e57d7c2e64979596c4fc21850bdda",
   "profile": "user",
   "projection": "mcp-agent-tool-schema-v1",
   "schema_version": "clio-kit.mcp-user-contract.v1",
@@ -81,7 +81,7 @@
         "additionalProperties": true,
         "type": "object"
       },
-      "title": "add(step)"
+      "title": "Add Step"
     },
     {
       "_meta": {
@@ -329,7 +329,7 @@
         "additionalProperties": true,
         "type": "object"
       },
-      "title": "create(jarvis run)"
+      "title": "Create Jarvis Run"
     },
     {
       "_meta": {
@@ -1563,7 +1563,7 @@
         "type": "object",
         "x-fastmcp-wrap-result": true
       },
-      "title": "describe(jarvis)"
+      "title": "Describe"
     },
     {
       "_meta": {
@@ -1622,7 +1622,7 @@
         "additionalProperties": true,
         "type": "object"
       },
-      "title": "edit(step)"
+      "title": "Edit Step"
     },
     {
       "_meta": {
@@ -3101,7 +3101,7 @@
         ],
         "type": "object"
       },
-      "title": "get(execution)"
+      "title": "Get Execution"
     },
     {
       "_meta": {
@@ -3844,8 +3844,8 @@
         ],
         "type": "object"
       },
-      "title": "start(execution)"
+      "title": "Start Execution"
     }
   ],
-  "wire_sha256": "1353209b546f438430c55a86c066a4aedc84cc306f399d110c966d4c688f0bc7"
+  "wire_sha256": "0f912b4dfa7135448834f915984ca413f77b73ef53b0f758594006cd7551cd35"
 }

--- a/src/clio_kit/_mcp_contracts/scientific-catalog-user-v1.1.json
+++ b/src/clio_kit/_mcp_contracts/scientific-catalog-user-v1.1.json
@@ -1,7 +1,7 @@
 {
   "canonicalization": "json-sort-keys-compact-utf8-v1",
   "contract_id": "clio-kit-scientific-catalog-user-v1.1",
-  "contract_sha256": "b5de9cd81ad2d8bab463b56669165535737a0954fa0a944b25da4a0c9325aaba",
+  "contract_sha256": "fd9fd4ba76617f1fd13560420cd650f78adc55d0957bd950d10d09c72ebe1889",
   "profile": "user",
   "projection": "mcp-agent-tool-schema-v1",
   "schema_version": "clio-kit.mcp-user-contract.v1",
@@ -461,7 +461,7 @@
         ],
         "type": "object"
       },
-      "title": "describe(dataset)"
+      "title": "Describe Dataset"
     },
     {
       "_meta": {
@@ -666,8 +666,8 @@
         ],
         "type": "object"
       },
-      "title": "search(dataset)"
+      "title": "Search Datasets"
     }
   ],
-  "wire_sha256": "6b81cd7593c415df4b6f2a14e40df9b698ee8ea8d6cfd5a7adef4b8ef36b50e2"
+  "wire_sha256": "6a8fc61e31515880c722db3447d2f01584e4b297cb02b70b5618bff081840380"
 }

--- a/src/clio_kit/_mcp_contracts/slurm-user-v3.json
+++ b/src/clio_kit/_mcp_contracts/slurm-user-v3.json
@@ -1,7 +1,7 @@
 {
   "canonicalization": "json-sort-keys-compact-utf8-v1",
   "contract_id": "clio-kit-slurm-user-v3",
-  "contract_sha256": "b1783c194b60ad6b791582fbf1783d7f0770fddf2a880da1d78bc7c4069feeb7",
+  "contract_sha256": "f61b27b0c7d4648d86c27b29504688a13ba45767bd75bfc372c830308f7c05c0",
   "profile": "user",
   "projection": "mcp-agent-tool-schema-v1",
   "schema_version": "clio-kit.mcp-user-contract.v1",
@@ -114,7 +114,7 @@
         ],
         "type": "object"
       },
-      "title": "cancel(job)"
+      "title": "Cancel Job"
     },
     {
       "_meta": {
@@ -408,7 +408,7 @@
         ],
         "type": "object"
       },
-      "title": "snapshot(cluster)"
+      "title": "Cluster Snapshot"
     },
     {
       "_meta": {
@@ -562,7 +562,7 @@
         ],
         "type": "object"
       },
-      "title": "describe(job)"
+      "title": "Describe Job"
     },
     {
       "_meta": {
@@ -761,7 +761,7 @@
         ],
         "type": "object"
       },
-      "title": "list(jobs)"
+      "title": "List Jobs"
     },
     {
       "_meta": {
@@ -957,8 +957,8 @@
         ],
         "type": "object"
       },
-      "title": "submit(job)"
+      "title": "Submit Job"
     }
   ],
-  "wire_sha256": "29dcc199e98f38cc4d3edcd97c081f486e37291c7b9b4d0477684b4e58642e40"
+  "wire_sha256": "8da5ea375d75d04052f766b02071fa4f41a2b61494b739e0e806eed02da532db"
 }

--- a/src/clio_kit/_mcp_contracts/spack-user-v2.1.json
+++ b/src/clio_kit/_mcp_contracts/spack-user-v2.1.json
@@ -1,7 +1,7 @@
 {
   "canonicalization": "json-sort-keys-compact-utf8-v1",
   "contract_id": "clio-kit-spack-user-v2.1",
-  "contract_sha256": "c9415541797dab178d5bdc797c6c03b259b462139fd8ab4069334b9871aef7a0",
+  "contract_sha256": "4a065d2c67c0dd34e2cc18bca9dc53ed87ce35aa4ac524ef3e5c954a875c19db",
   "profile": "user",
   "projection": "mcp-agent-tool-schema-v1",
   "schema_version": "clio-kit.mcp-user-contract.v1",
@@ -146,7 +146,7 @@
         ],
         "type": "object"
       },
-      "title": "find(packages)"
+      "title": "Find Packages"
     },
     {
       "_meta": {
@@ -295,7 +295,7 @@
         ],
         "type": "object"
       },
-      "title": "install(package)"
+      "title": "Install Package"
     },
     {
       "_meta": {
@@ -417,8 +417,8 @@
         ],
         "type": "object"
       },
-      "title": "locate(package)"
+      "title": "Locate Package"
     }
   ],
-  "wire_sha256": "898e43be33f7ab61130ee1b0b1ec5458f60e32ad27a1ad96fd806902266c9dc3"
+  "wire_sha256": "c7f1d1a4ce35b58664b46d2994863257a1e5a30e5c4ab7501b0a96a4becc08b7"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.7.0"
+version = "2.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Renames all 231 tool titles across 24 servers from the 2.7.0 `verb(object)` register (e.g. `geocode(place)`) to short plain Title Case names (e.g. `Geocode`) — parens are a UI-injected decoration around the call's arguments, not part of the title. Sibling tool families that would otherwise collide on a plain name disambiguate in plain words (jarvis: "Create Pipeline" vs "Create Jarvis Run", "Run Pipeline" vs "Start Execution"; slurm: "Submit Job" vs "Submit Slurm Job").
- Adopts MCP 2026-07-28 output semantics for the demo-critical servers:
  - `plot`: every plot tool now returns a proper `ImageContent` block (base64 PNG, downscaled to a bounded ~800px preview) alongside its structured dict, via `ToolResult(content=[Image(...)], structured_content=...)`. `output_path` in the structured dict still points at the full-resolution file on disk.
  - `plot`, `pandas`, `ndp`, `geo`: tool return annotations move from bare `dict` to precise `TypedDict`s grounded in each implementation's actual runtime return shape, so FastMCP derives a real per-field `outputSchema` instead of the generic `{"type": "object", "additionalProperties": true}`.
- Bumps to 2.7.1 and regenerates every publishing manifest (server.json per server, marketplace.json, gemini-extension.json, and the 4 curated MCP user contracts whose digests move because they project `Tool.title`).

## Test plan
- [x] `uv run pytest tests/` green for all 24 servers individually plus the root suite (zero skipped, verified via `scripts/assert_no_skipped_tests.py` for the release-required servers: jarvis, scientific-catalog, slurm, spack)
- [x] `uv run ruff check .` / `ruff format --check .` clean across every touched server and root `scripts src tests`
- [x] `uv run mypy src/ --ignore-missing-imports` (the exact CI invocation) clean for plot/pandas/ndp/geo; `mypy src` clean (zero pre-existing baseline errors too) for jarvis/scientific-catalog/slurm/spack
- [x] `scripts/validate_fastmcp.py` PASS for all 24 servers
- [x] New in-memory `Client` tests assert an `image/png` content block + intact `structuredContent` for plot tools, and a real field-level `outputSchema` on `tools/list` for plot/pandas/ndp/geo
- [x] `git diff --exit-code` equivalent: regenerated manifests match what's committed (root test suite includes this contract)