### PR TITLE
fix(jarvis): rank package search over the declared configuration contract (2.7.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.7.1",
+    "version": "2.7.2",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
@@ -6,6 +6,7 @@ import importlib
 import json
 import os
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Annotated, Any, Literal, Optional, cast
@@ -2379,7 +2380,15 @@ def _search_packages(
         )
 
     inventory = _discover_package_inventory()
-    inventory_revision = _package_inventory_revision(inventory)
+    # The declared configuration contract is part of what ranks and pages this
+    # search, so it is also part of the revision the cursor is bound to: a menu
+    # that changes between pages must invalidate the cursor exactly as a
+    # changed docstring already does.
+    configuration_texts = {
+        package.name: _package_configuration_search_text(package.name)
+        for package in inventory
+    }
+    inventory_revision = _package_inventory_revision(inventory, configuration_texts)
     query_sha256 = hashlib.sha256(
         normalized_query.casefold().encode("utf-8")
     ).hexdigest()
@@ -2387,7 +2396,14 @@ def _search_packages(
         (
             (rank, package)
             for package in inventory
-            if (rank := _package_search_rank(package, normalized_query)) is not None
+            if (
+                rank := _package_search_rank(
+                    package,
+                    normalized_query,
+                    configuration_texts.get(package.name, ""),
+                )
+            )
+            is not None
         ),
         key=lambda item: (item[0], item[1].name.casefold(), item[1].name),
     )
@@ -2443,11 +2459,66 @@ def _search_packages(
         page.pop()
 
 
+def _package_configuration_search_text(package_name: str) -> str:
+    """Return one package's declared agent-visible configuration as search text.
+
+    Discovery ranks over what a package DECLARES, not only over the module
+    docstring that ``_first_docstring_or_comment`` scrapes. A caller looking
+    for a package that accepts a *staged local input* has no other way to find
+    one: the bounded search summary carries identity only, and a setting's
+    ``input_binding`` -- the single authoritative staging signal -- lives in
+    the package's configure menu, which search never consulted. Every term
+    here is package-declared (setting names, setting prose, and the binding's
+    own ``kind``/``structure`` vocabulary); nothing about specific packages is
+    encoded in this function.
+
+    Loading is best-effort by design and mirrors
+    :func:`_package_agent_metadata`'s existing treatment of an unloadable
+    menu: a package that cannot be imported contributes no configuration text
+    and stays rankable by identity exactly as before, so one broken package in
+    a registered repository can never fail a whole search.
+    """
+
+    try:
+        from jarvis_cd.core.pkg import Pkg  # type: ignore[import-untyped]
+
+        pkg = Pkg.load_standalone(package_name)
+        settings = [
+            _setting_from_menu_item(item)
+            for item in pkg.configure_menu()
+            if _setting_is_agent_visible(item)
+        ]
+    except Exception:
+        return ""
+
+    terms: list[str] = []
+    for setting in settings:
+        for field in ("name", "description"):
+            value = setting.get(field)
+            if isinstance(value, str) and value:
+                terms.append(value)
+        binding = setting.get("input_binding")
+        if isinstance(binding, dict):
+            terms.append("input_binding")
+            for field in ("kind", "structure"):
+                value = binding.get(field)
+                if isinstance(value, str) and value:
+                    terms.append(value)
+    return " ".join(terms)
+
+
 def _package_search_rank(
     package: _PackageInventoryEntry,
     query: str,
+    configuration_text: str = "",
 ) -> int | None:
-    """Return a deterministic relevance rank, or ``None`` when no field matches."""
+    """Return a deterministic relevance rank, or ``None`` when no field matches.
+
+    Ranks 0-4 are identity and docstring matches and are unchanged. Ranks 5
+    and 6 are the package's own declared configuration contract, which ranks
+    below every identity match so an exact name never loses to a setting that
+    merely mentions the query.
+    """
 
     folded_query = query.casefold()
     folded_name = package.name.casefold()
@@ -2467,7 +2538,7 @@ def _package_search_rank(
     normalized_query = _package_search_terms(folded_query)
     if not normalized_query:
         return None
-    searchable = _package_search_terms(
+    identity_terms = _package_search_terms(
         " ".join(
             (
                 package.name,
@@ -2476,8 +2547,15 @@ def _package_search_rank(
             )
         ).casefold()
     )
-    if all(term in searchable for term in normalized_query):
+    if all(term in identity_terms for term in normalized_query):
         return 4
+
+    folded_configuration = configuration_text.casefold()
+    if folded_configuration and folded_query in folded_configuration:
+        return 5
+    searchable = identity_terms + _package_search_terms(folded_configuration)
+    if all(term in searchable for term in normalized_query):
+        return 6
     return None
 
 
@@ -2487,9 +2565,13 @@ def _package_search_terms(value: str) -> list[str]:
     return [term for term in re.split(r"[^a-z0-9]+", value) if term]
 
 
-def _package_inventory_revision(inventory: list[_PackageInventoryEntry]) -> str:
-    """Hash the full lightweight inventory used to rank and page package search."""
+def _package_inventory_revision(
+    inventory: list[_PackageInventoryEntry],
+    configuration_texts: Mapping[str, str] | None = None,
+) -> str:
+    """Hash the full inventory used to rank and page package search."""
 
+    texts = configuration_texts or {}
     hasher = hashlib.sha256()
     hasher.update(b"clio-kit.jarvis-package-inventory.v1\0")
     for package in inventory:
@@ -2499,6 +2581,7 @@ def _package_inventory_revision(inventory: list[_PackageInventoryEntry]) -> str:
                 "short_name": package.short_name,
                 "repository": package.repository,
                 "description": package.description,
+                "configuration": texts.get(package.name, ""),
             }
         )
         hasher.update(len(encoded).to_bytes(8, "big"))

--- a/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
@@ -12,6 +12,7 @@ from fastmcp.exceptions import ToolError
 from jarvis_mcp.server import (
     PACKAGE_SEARCH_MAX_RESULT_BYTES,
     _PackageAgentMetadata,
+    _package_configuration_search_text,
     _setting_from_menu_item,
     jarvis_describe_tool,
     mcp,
@@ -552,6 +553,60 @@ async def test_package_search_survives_a_package_that_cannot_be_loaded(
         result = await jarvis_describe_tool("package_search", query="echo")
 
     assert [package["name"] for package in result["packages"]] == ["builtin.echo"]
+
+
+def test_configuration_search_text_projects_settings_and_binding_vocabulary() -> None:
+    """The real (unmocked) implementation extracts declared search terms.
+
+    Unit-level, deterministic coverage of ``_package_configuration_search_text``
+    itself: this must not depend on how a real ``jarvis_cd`` install happens to
+    load a bare test-fixture package (that behavior is an accident of the
+    installed runtime, not a contract this function owns).
+    """
+
+    menu = [
+        {"name": "tasks", "msg": "Number of parallel tasks to launch."},
+        {
+            "name": "script",
+            "msg": "Caller-local script staged onto the cluster.",
+            "input_binding": {
+                "schema_version": "jarvis.configuration-input-binding.v1",
+                "kind": "local_file",
+                "structure": "regular_file",
+            },
+        },
+        {"name": "internal_flag", "msg": "Hidden from agents.", "agent_visible": False},
+    ]
+    package = Mock()
+    package.configure_menu.return_value = menu
+
+    with patch("jarvis_cd.core.pkg.Pkg.load_standalone", return_value=package):
+        text = _package_configuration_search_text("site.example")
+
+    for expected in (
+        "tasks",
+        "Number of parallel tasks to launch.",
+        "script",
+        "Caller-local script staged onto the cluster.",
+        "input_binding",
+        "local_file",
+        "regular_file",
+    ):
+        assert expected in text
+    # The setting marked ``agent_visible: False`` is filtered before any of
+    # its text can reach the search corpus.
+    assert "internal_flag" not in text
+    assert "Hidden from agents" not in text
+
+
+def test_configuration_search_text_is_best_effort_for_an_unloadable_package() -> None:
+    """A package that cannot be loaded contributes no configuration text."""
+
+    def explode(package_name: str) -> str:
+        raise RuntimeError(f"cannot import {package_name}")
+
+    with patch("jarvis_cd.core.pkg.Pkg.load_standalone", side_effect=explode):
+        assert _package_configuration_search_text("site.broken") == ""
 
 
 @pytest.mark.asyncio

--- a/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
@@ -335,7 +335,14 @@ async def test_ambiguous_short_name_fails_with_canonical_candidates(
 async def test_package_search_is_ranked_summary_only_and_cursor_bound(
     tmp_path: Path,
 ) -> None:
-    """Search ranks deterministically without importing package settings."""
+    """Search ranks deterministically and never loads full agent metadata.
+
+    Discovery may read a package's declared configuration menu (see
+    ``test_package_search_finds_packages_by_declared_input_binding``) but must
+    never take the ``_package_agent_metadata`` path, whose deployment-contract
+    validation raises ``ToolError`` -- one package's bad contract must not be
+    able to fail an unrelated search.
+    """
 
     repo = tmp_path / "repo"
     _write_package(repo, "builtin.paraview", "Generic visualization runtime.")
@@ -430,6 +437,109 @@ async def test_package_search_enforces_response_byte_ceiling(tmp_path: Path) -> 
     assert 0 < result["returned_count"] < 25
     assert result["total_matches"] == 60
     assert isinstance(result["next_cursor"], str)
+
+
+@pytest.mark.asyncio
+async def test_package_search_finds_packages_by_declared_input_binding(
+    tmp_path: Path,
+) -> None:
+    """A staged-input package is discoverable through its declared contract.
+
+    Live regression (p5run2): an agent that had authored a local script
+    searched ``shell`` and ``script``, and the only package it could reach
+    declared no ``input_binding`` at all, so its file was never staged and the
+    job ran ``bash marker.sh`` in a directory that never received the file.
+    The package that DOES declare the binding was unreachable because search
+    ranked over module docstrings only.
+    """
+
+    repo = tmp_path / "repo"
+    _write_package(repo, "builtin.my_shell", "Launch the MyShell application.")
+    _write_package(repo, "site.bounded_command", "Package for bounded commands.")
+    _write_package(repo, "site.unrelated", "Unrelated application.")
+
+    declared = {
+        "builtin.my_shell": [{"name": "script", "msg": "The path of shell script."}],
+        "site.bounded_command": [
+            {
+                "name": "command",
+                "msg": "Argument vector to execute. No shell is interposed.",
+            },
+            {
+                "name": "script",
+                "msg": "Caller-local script staged onto the cluster.",
+                "input_binding": {
+                    "schema_version": "jarvis.configuration-input-binding.v1",
+                    "kind": "local_file",
+                    "structure": "regular_file",
+                },
+            },
+        ],
+    }
+
+    def configuration_text(package_name: str) -> str:
+        menu = declared.get(package_name)
+        if menu is None:
+            return ""
+        return " ".join(
+            part
+            for item in menu
+            for part in (
+                item["name"],
+                item["msg"],
+                *(
+                    ("input_binding", "local_file", "regular_file")
+                    if "input_binding" in item
+                    else ()
+                ),
+            )
+        )
+
+    with (
+        patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
+        patch(
+            "jarvis_mcp.server._package_configuration_search_text",
+            side_effect=configuration_text,
+        ),
+    ):
+        shell = await jarvis_describe_tool("package_search", query="shell")
+        binding = await jarvis_describe_tool("package_search", query="local_file")
+
+    # The identity match still ranks first; the declared contract adds the
+    # candidate the agent could not otherwise reach.
+    assert [package["name"] for package in shell["packages"]] == [
+        "builtin.my_shell",
+        "site.bounded_command",
+    ]
+    # The binding's own declared vocabulary is a capability query.
+    assert [package["name"] for package in binding["packages"]] == [
+        "site.bounded_command"
+    ]
+    # The wire projection is unchanged: identity only, never settings.
+    for package in shell["packages"] + binding["packages"]:
+        assert set(package) <= {"name", "short_name", "repository", "description"}
+
+
+@pytest.mark.asyncio
+async def test_package_search_survives_a_package_that_cannot_be_loaded(
+    tmp_path: Path,
+) -> None:
+    """One unloadable package must not fail a whole discovery request."""
+
+    repo = tmp_path / "repo"
+    _write_package(repo, "builtin.broken", "Broken package.")
+    _write_package(repo, "builtin.echo", "Echo package.")
+
+    def explode(package_name: str) -> str:
+        raise RuntimeError(f"cannot import {package_name}")
+
+    with (
+        patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
+        patch("jarvis_cd.core.pkg.Pkg.load_standalone", side_effect=explode),
+    ):
+        result = await jarvis_describe_tool("package_search", query="echo")
+
+    assert [package["name"] for package in result["packages"]] == ["builtin.echo"]
 
 
 @pytest.mark.asyncio

--- a/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
@@ -504,6 +504,13 @@ async def test_package_search_finds_packages_by_declared_input_binding(
     ):
         shell = await jarvis_describe_tool("package_search", query="shell")
         binding = await jarvis_describe_tool("package_search", query="local_file")
+        # "shell" and "binding" never appear together as a contiguous phrase
+        # in any declared text (rank 5's substring check misses), but both
+        # terms individually appear in bounded_command's configuration
+        # ("...No shell is interposed"... "input_binding..." tokenizes to
+        # "binding"). This is rank 6: every query term present somewhere in
+        # the combined identity+configuration vocabulary, order-independent.
+        scattered = await jarvis_describe_tool("package_search", query="shell binding")
 
     # The identity match still ranks first; the declared contract adds the
     # candidate the agent could not otherwise reach.
@@ -515,8 +522,13 @@ async def test_package_search_finds_packages_by_declared_input_binding(
     assert [package["name"] for package in binding["packages"]] == [
         "site.bounded_command"
     ]
+    # Only the package whose declared configuration contains BOTH scattered
+    # terms matches; my_shell has "shell" but no "binding" anywhere.
+    assert [package["name"] for package in scattered["packages"]] == [
+        "site.bounded_command"
+    ]
     # The wire projection is unchanged: identity only, never settings.
-    for package in shell["packages"] + binding["packages"]:
+    for package in shell["packages"] + binding["packages"] + scattered["packages"]:
         assert set(package) <= {"name", "short_name", "repository", "description"}
 
 

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/web/server.json
+++ b/clio-kit-mcp-servers/web/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.7.1"
+version = "2.7.2"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.7.1"
+version = "2.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Closes #353. `_search_packages` now ranks a package's declared agent-visible configuration (setting names, setting prose, and a binding's kind/structure vocabulary) in two new tiers below every existing identity/docstring tier, so a package whose only description of its stageable input lives in its settings (not its module docstring) becomes reachable by search. No existing match order changes.
- `tools/list` is byte-identical to 2.7.1 (verified locally via a before/after sha256 of the live jarvis tools/list), so the pinned `clio-kit-jarvis-user-v3.6` contract digest, `mcp-server-versions.toml`, and the four curated MCP user contracts are correctly untouched by this release.
- `chore(release): prepare 2.7.2` bumps the root package version and regenerates every publishing manifest (server.json x24, marketplace.json, gemini-extension.json) from live FastMCP metadata.

## Test plan

- [x] `uv run pytest -q` in `clio-kit-mcp-servers/jarvis`: 417 passed
- [x] `uv run ruff check .` / `uv run ruff format --check .` clean for jarvis
- [x] `uv run mypy src --ignore-missing-imports --show-error-codes --no-error-summary` clean for jarvis
- [x] `uv run python ../../scripts/validate_fastmcp.py`: PASS
- [x] Live jarvis `tools/list` sha256 identical before (origin/main @ 2.7.1) and after this branch: `eb2da02b52b6cd8b73bae5e38d36eb56a61a545b608b830014ab93352a745d0e`
- [x] `uv run python scripts/generate_server_json.py clio-kit-mcp-servers` then `git diff --exit-code` on the CI-checked manifest paths: only the intended version-bump lines changed, no contract drift